### PR TITLE
chore: ignore IDE and lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,12 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# VSCode and Intellij
+.vscode
+.idea
+*.iml
+
+# Lock files
+yarn.lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ typings/
 .idea
 *.iml
 
+# MacOS
+.DS_Store
+
 # Lock files
 yarn.lock
 package-lock.json


### PR DESCRIPTION
Currently, both npm and yarn lock files are missing from git repo. While it may be better to include one of those (I think you internally use yarn) if the decision is to not include them, we may gitignore them to prevent accidental commits.

This PR also ignores code editor specific config files and `.DS_Store`.