### PR TITLE
Match package.json node engines to the docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "nearform/node-clinic",
   "version": "1.0.2",
   "engines": {
-    "node": "^9.4.0 || ^8.9.4"
+    "node": "^10.0.0 || ^9.4.0 || ^8.9.4"
   },
   "bin": {
     "clinic": "./bin.js"


### PR DESCRIPTION
It refuses to install against node 10.8.0 due to the spec in `package.json`. After adjusting node engines the tests are still passing.