### PR TITLE
Added upload with --ask

### DIFF
--- a/docs/clinic-upload.txt
+++ b/docs/clinic-upload.txt
@@ -16,3 +16,4 @@
 
   <h1>Flags</h1>
   -h | --help                Display Help
+  --ark                      Uploads in private upload server area (requires authentication)

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -1,0 +1,32 @@
+const opn = require('opn')
+const randtoken = require('rand-token')
+const websocket = require('websocket-stream')
+const split2 = require('split2')
+const { ReadableStreamBuffer } = require('stream-buffers')
+const { URL } = require('url')
+const get = require('simple-get')
+
+/**
+ * Get the JWT token from the Upload server specified by the URL.
+ * - create a random tokens
+ * - open a websocket on the server
+ * - push the token through the websocket
+ * - Open the browser on `http://localhost:3000/?token=${cliToken}`
+ * - Get the JWT from the web websocket
+ */
+const authenticate = url =>
+  new Promise ((resolve, reject) => {
+    const cliToken = randtoken.generate(128)
+    const parsedURL = new URL(url)
+    parsedURL.protocol = 'ws:/'
+    const wsUrl = parsedURL.toString()
+    const ws = websocket(wsUrl)
+    const readBuffer = new ReadableStreamBuffer()
+    readBuffer.put(cliToken + '\n')
+    readBuffer.pipe(ws).pipe(split2()).on('data', auth0Token => resolve(auth0Token))
+    // Open the url in the default browser
+    const cliLoginUrl = `${url}?token=${cliToken}`
+    opn(cliLoginUrl, { wait: false })
+  })
+
+module.exports = authenticate

--- a/lib/tar-and-upload.js
+++ b/lib/tar-and-upload.js
@@ -9,7 +9,7 @@ const zlib = require('zlib')
 
 module.exports = tarAndUpload
 
-function tarAndUpload (filePrefix, uploadUrl, cb) {
+function tarAndUpload (filePrefix, uploadUrl, authToken, cb) {
   const parentDirectory = path.dirname(filePrefix)
 
   let empty = true
@@ -50,11 +50,19 @@ function tarAndUpload (filePrefix, uploadUrl, cb) {
     if (err) return cb(err)
     if (empty) return cb(new Error('No data to upload'))
 
-    get.concat({
+    const opts = {
       method: 'POST',
-      url: uploadUrl + '/data',
+      url: uploadUrl + (authToken ? '/protected/data' : '/data'),
       body: Buffer.concat(zipped)
-    }, onupload)
+    }
+
+    if (authToken) {
+      opts.headers = {
+        'Authorization': `Bearer ${authToken}`
+      }
+    }
+
+    get.concat(opts, onupload)
   }
 
   function onupload (err, res, body) {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,16 @@
     "env-string": "^1.0.0",
     "execspawn": "^1.0.1",
     "minimist": "^1.2.0",
-    "opn": "^5.2.0",
+    "opn": "^5.4.0",
     "pumpify": "^1.4.0",
+    "rand-token": "^0.4.0",
     "rimraf": "^2.6.2",
-    "simple-get": "^3.0.0",
+    "simple-get": "^3.0.3",
+    "split2": "^3.0.0",
+    "stream-buffers": "^3.0.2",
     "stream-collector": "^1.0.1",
-    "tar-fs": "^1.16.0"
+    "tar-fs": "^1.16.0",
+    "websocket-stream": "^5.1.2"
   },
   "devDependencies": {
     "autocannon": "^3.0.0",


### PR DESCRIPTION
If upload is launched with `--ask` option the CLI:

- Start the authentication on upload server to obtain a JWT token
- Uploads to the protected API `/protected/data`.

On the server side, the API can extract the user email from the JWT token.