### PR TITLE
adding `presentationMode` flag to CLI

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -186,21 +186,24 @@ const result = commist()
     const args = minimist(argv, {
       alias: {
         help: 'h',
-        version: 'v'
+        version: 'v',
+        presentationMode: 'pm'
       },
       boolean: [
         'help',
         'version',
         'collect-only',
         'open',
-        'debug'
+        'debug',
+        'presentationMode'
       ],
       string: [
         'visualize-only'
       ],
       default: {
         open: true,
-        debug: false
+        debug: false,
+        presentationMode: false
       },
       '--': true
     })
@@ -291,7 +294,8 @@ function runTool (args, Tool, version) {
     sampleInterval: parseInt(args['sample-interval'], 10),
     detectPort: !!onPort,
     dest: args.dest,
-    debug: args.debug
+    debug: args.debug,
+    presentationMode: args.presentationMode
   })
 
   /* istanbul ignore next */


### PR DESCRIPTION
This PR adds support to `--presentationMode` flag (alias `--pm`) to default Flame app in presentation mode

Usage example:
`clinic flame --presentationMode -- NODE ../node-clinic-doctor-examples/slow-event-loop outputs`
or
`clinic flame --pm -- NODE ../node-clinic-doctor-examples/slow-event-loop outputs`