### PR TITLE
Strip trailing slash from --visualize-only.

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -313,12 +313,13 @@ function runTool (args, Tool, version) {
       console.log(`Output file is ${filename}`)
     })
   } else if (args['visualize-only']) {
-    viz(args['visualize-only'], function (err) {
+    const dataPath = args['visualize-only'].replace(/\/$/, '')
+    viz(dataPath, function (err) {
       if (err) throw err
 
-      console.log(`Generated HTML file is ${args['visualize-only']}.html`)
+      console.log(`Generated HTML file is ${dataPath}.html`)
       console.log('You can use this command to upload it:')
-      console.log(`clinic upload ${args['visualize-only']}`)
+      console.log(`clinic upload ${dataPath}`)
     })
   } else {
     tool.collect(args['--'], function (err, filename) {

--- a/bin.js
+++ b/bin.js
@@ -313,7 +313,7 @@ function runTool (args, Tool, version) {
       console.log(`Output file is ${filename}`)
     })
   } else if (args['visualize-only']) {
-    const dataPath = args['visualize-only'].replace(/\/$/, '')
+    const dataPath = args['visualize-only'].replace(/[\\/]$/, '')
     viz(dataPath, function (err) {
       if (err) throw err
 

--- a/test/cli-bubbleprof-visualize-only.test.js
+++ b/test/cli-bubbleprof-visualize-only.test.js
@@ -62,7 +62,7 @@ test('clinic bubbleprof --visualize-only - with trailing /', function (t) {
 
     // visualize data
     cli({}, [
-      'clinic', 'bubbleprof', '--visualize-only', `${dirpath}/`
+      'clinic', 'bubbleprof', '--visualize-only', `${dirpath}${path.sep}`
     ], function (err, stdout) {
       t.ifError(err)
       t.strictEqual(

--- a/test/cli-bubbleprof-visualize-only.test.js
+++ b/test/cli-bubbleprof-visualize-only.test.js
@@ -48,3 +48,35 @@ test('clinic bubbleprof --collect-only - missing data', function (t) {
     t.end()
   })
 })
+
+test('clinic bubbleprof --visualize-only - with trailing /', function (t) {
+  // collect data
+  cli({}, [
+    'clinic', 'bubbleprof', '--collect-only',
+    '--', 'node', '-e', 'setTimeout(() => {}, 100)'
+  ], function (err, stdout, stderr, tempdir) {
+    t.ifError(err)
+    t.ok(/Output file is (\d+).clinic-bubbleprof/.test(stdout))
+    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    const dirpath = path.resolve(tempdir, dirname)
+
+    // visualize data
+    cli({}, [
+      'clinic', 'bubbleprof', '--visualize-only', `${dirpath}/`
+    ], function (err, stdout) {
+      t.ifError(err)
+      t.strictEqual(
+        stdout,
+        `Generated HTML file is ${dirpath}.html
+You can use this command to upload it:
+clinic upload ${dirpath}
+`)
+
+      // check that HTML file exists
+      fs.access(dirpath + '.html', function (err) {
+        t.ifError(err)
+        t.end()
+      })
+    })
+  })
+})

--- a/test/cli-doctor-visualize-only.test.js
+++ b/test/cli-doctor-visualize-only.test.js
@@ -62,7 +62,7 @@ test('clinic doctor --visualize-only - supports trailing slash', function (t) {
 
     // visualize data
     cli({}, [
-      'clinic', 'doctor', '--visualize-only', `${dirpath}/`
+      'clinic', 'doctor', '--visualize-only', `${dirpath}${path.sep}`
     ], function (err, stdout) {
       t.ifError(err)
       t.strictEqual(

--- a/test/cli-flame-visualize-only.test.js
+++ b/test/cli-flame-visualize-only.test.js
@@ -62,7 +62,7 @@ test('clinic flame --visualize-only - supports trailing slash', function (t) {
 
     // visualize data
     cli({}, [
-      'clinic', 'flame', '--visualize-only', `${dirpath}/`
+      'clinic', 'flame', '--visualize-only', `${dirpath}${path.sep}`
     ], function (err, stdout) {
       t.ifError(err)
       t.strictEqual(

--- a/test/cli-flame-visualize-only.test.js
+++ b/test/cli-flame-visualize-only.test.js
@@ -5,20 +5,20 @@ const path = require('path')
 const test = require('tap').test
 const cli = require('./cli.js')
 
-test('clinic doctor --visualize-only - no issues', function (t) {
+test('clinic flame --visualize-only - no issues', function (t) {
   // collect data
   cli({}, [
-    'clinic', 'doctor', '--collect-only',
-    '--', 'node', '-e', 'setTimeout(() => {}, 100)'
+    'clinic', 'flame', '--collect-only',
+    '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-doctor/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    t.ok(/Output file is (\d+).clinic-flame/.test(stdout))
+    const dirname = stdout.match(/(\d+.clinic-flame)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
     cli({}, [
-      'clinic', 'doctor', '--visualize-only', dirpath
+      'clinic', 'flame', '--visualize-only', dirpath
     ], function (err, stdout) {
       t.ifError(err)
       t.strictEqual(
@@ -37,10 +37,10 @@ clinic upload ${dirpath}
   })
 })
 
-test('clinic doctor --visualize-only - missing data', function (t) {
-  const arg = 'missing.clinic-doctor'
+test('clinic flame --visualize-only - missing data', function (t) {
+  const arg = 'missing.clinic-flame'
   cli({ relayStderr: false }, [
-    'clinic', 'doctor', '--visualize-only', arg
+    'clinic', 'flame', '--visualize-only', arg
   ], function (err, stdout, stderr) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.strictEqual(stdout, '')
@@ -49,20 +49,20 @@ test('clinic doctor --visualize-only - missing data', function (t) {
   })
 })
 
-test('clinic doctor --visualize-only - supports trailing slash', function (t) {
+test('clinic flame --visualize-only - supports trailing slash', function (t) {
   // collect data
   cli({}, [
-    'clinic', 'doctor', '--collect-only',
-    '--', 'node', '-e', 'setTimeout(() => {}, 100)'
+    'clinic', 'flame', '--collect-only',
+    '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-doctor/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    t.ok(/Output file is (\d+).clinic-flame/.test(stdout))
+    const dirname = stdout.match(/(\d+.clinic-flame)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
     cli({}, [
-      'clinic', 'doctor', '--visualize-only', `${dirpath}/`
+      'clinic', 'flame', '--visualize-only', `${dirpath}/`
     ], function (err, stdout) {
       t.ifError(err)
       t.strictEqual(


### PR DESCRIPTION
Fixes an issue where the visualizer HTML file could be output to `{pid}.clinic-{tool}/.html`.


This fixes it for all tools, because the output file name is passed in by the Clinic CLI and not determined separatly in each tool.