### PR TITLE
Remove coverage ignore comments for Flame.

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -211,8 +211,7 @@ const result = commist()
       printVersion(version)
     } else if (args.help) {
       printHelp('clinic-flame', version)
-    } /* istanbul ignore next */ else if (args['visualize-only'] || args['--'].length > 1) {
-      /* istanbul ignore next */
+    } else if (args['visualize-only'] || args['--'].length > 1) {
       trackTool('flame', args, version, () => {
         runTool(args, require('@nearform/flame'))
       })


### PR DESCRIPTION
The flame CLI has some tests now so we don't need to opt out of coverage.