### PR TITLE
Move autocannon out of dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nearform/flame": "^3.4.1",
     "any-shell-escape": "^0.1.1",
     "async": "^2.6.0",
+    "autocannon": "^3.2.0",
     "commist": "^1.0.0",
     "cross-argv": "^1.0.0",
     "dargs": "^6.0.0",
@@ -40,7 +41,6 @@
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {
-    "autocannon": "^3.1.0",
     "snazzy": "^8.0.0",
     "standard": "^12.0.0",
     "tap": "^12.1.0",


### PR DESCRIPTION
Should fix #94

There is a reference to `autocannon` [here](https://github.com/nearform/node-clinic/blob/master/bin.js#L289), but I guess since it's in the `devDependencies` it's not getting installed.