### PR TITLE
Fix infinite spinner on --collect-only

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -355,6 +355,10 @@ function runTool (args, Tool, version, uiOptions) {
     process.once('SIGINT', onsigint)
     tool.collect(args['--'], function (err, filename) {
       if (err) throw err
+      if (spinner.isEnabled) {
+        spinner.stop()
+        spinner.stream.write(`${spinner.text}\n`)
+      }
       console.log(`Output file is ${filename}`)
     })
   } else if (args['visualize-only']) {


### PR DESCRIPTION
In --collect-only, the CLI wasn't stopping the spinner after it completed. The spinner uses `setInterval` so it would just keep going indefinitely, preventing the process from exiting. Now it's correctly stopped.