### PR TITLE
[471] - Update engine property with correct minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "nearform/node-clinic",
   "version": "2.2.1",
   "engines": {
-    "node": "^11.0.0 || ^10.0.0 || ^8.9.4"
+    "node": "^11.0.0 || ^10.0.0 || >=8.11.1"
   },
   "bin": {
     "clinic": "./bin.js"


### PR DESCRIPTION
Updates minimum [inline with docs](https://clinicjs.org/documentation/)

Tested locally with a lower version (`8.0.0`) which throws the Trace Event error detailed in [this closed issue](https://github.com/nearform/node-clinic/issues/2), but works with `8.11.1`.