### PR TITLE
Store auth tokens in ~/.node-clinic-rc

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -60,14 +60,18 @@ const result = commist()
 
     function printUser (user) {
       if (user) {
-        console.log('Authenticated as ', user.name, `(${user.email})`)
+        if (user.name) {
+          console.log(`Authenticated as ${user.name} (${user.email}).`)
+        } else {
+          console.log(`Authenticated as ${user.email}.`)
+        }
       } else {
         console.log('Not authenticated')
       }
     }
 
     if (args['upload-url']) {
-      authenticate.getSession().then((user) => {
+      authenticate.getSession(args['upload-url']).then((user) => {
         if (!user) throw new Error('Expired')
         printUser(user)
       }).catch(() => {
@@ -76,7 +80,9 @@ const result = commist()
       })
     } else {
       authenticate.getSessions().then((users) => {
-        Object.keys(users).forEach((url) => {
+        const urls = Object.keys(users)
+        if (urls.length === 0) process.exit(1)
+        urls.forEach((url) => {
           console.log(helpFormatter(`<link>${url}</link>`))
           printUser(users[url])
           console.log('')
@@ -104,7 +110,11 @@ const result = commist()
 
     authenticate(args['upload-url']).then((authToken) => {
       const header = jwt.decode(authToken)
-      console.log('Logged in as', header.name, `(${header.email})`)
+      if (header.name) {
+        console.log(`Signed in as ${header.name} (${header.email}).`)
+      } else {
+        console.log(`Signed in as ${header.email}.`)
+      }
     }).catch((err) => {
       console.error('Authentication failure:', err.message)
       process.exit(1)
@@ -133,11 +143,11 @@ const result = commist()
 
     if (args.all) {
       authenticate.removeSessions().then(() => {
-        console.log('Logged out from all servers')
+        console.log('Signed out from all servers')
       })
     } else {
       authenticate.logout(args['upload-url']).then(() => {
-        console.log('Logged out from ', args['upload-url'])
+        console.log('Signed out from ', args['upload-url'])
       })
     }
   })

--- a/bin.js
+++ b/bin.js
@@ -49,7 +49,7 @@ const result = commist()
         help: 'h'
       },
       string: [
-        'upload-url'
+        'server'
       ]
     })
 
@@ -70,8 +70,8 @@ const result = commist()
       }
     }
 
-    if (args['upload-url']) {
-      authenticate.getSession(args['upload-url']).then((user) => {
+    if (args.server) {
+      authenticate.getSession(args.server).then((user) => {
         if (!user) throw new Error('Expired')
         printUser(user)
       }).catch(() => {
@@ -96,10 +96,10 @@ const result = commist()
         help: 'h'
       },
       string: [
-        'upload-url'
+        'server'
       ],
       default: {
-        'upload-url': DEFAULT_UPLOAD_URL
+        'server': DEFAULT_UPLOAD_URL
       }
     })
 
@@ -108,7 +108,7 @@ const result = commist()
       process.exit(0)
     }
 
-    authenticate(args['upload-url']).then((authToken) => {
+    authenticate(args.server).then((authToken) => {
       const header = jwt.decode(authToken)
       if (header.name) {
         console.log(`Signed in as ${header.name} (${header.email}).`)
@@ -126,13 +126,13 @@ const result = commist()
         help: 'h'
       },
       string: [
-        'upload-url'
+        'server'
       ],
       boolean: [
         'all'
       ],
       default: {
-        'upload-url': DEFAULT_UPLOAD_URL
+        'server': DEFAULT_UPLOAD_URL
       }
     })
 
@@ -146,8 +146,8 @@ const result = commist()
         console.log('Signed out from all servers')
       })
     } else {
-      authenticate.logout(args['upload-url']).then(() => {
-        console.log('Signed out from ', args['upload-url'])
+      authenticate.logout(args.server).then(() => {
+        console.log('Signed out from ', args.server)
       })
     }
   })
@@ -157,14 +157,14 @@ const result = commist()
         help: 'h'
       },
       string: [
-        'upload-url'
+        'server'
       ],
       boolean: [
         'help',
         'private'
       ],
       default: {
-        'upload-url': DEFAULT_UPLOAD_URL
+        'server': DEFAULT_UPLOAD_URL
       }
     })
 
@@ -196,13 +196,13 @@ const result = commist()
         help: 'h'
       },
       string: [
-        'upload-url'
+        'server'
       ],
       boolean: [
         'help'
       ],
       default: {
-        'upload-url': DEFAULT_UPLOAD_URL
+        'server': DEFAULT_UPLOAD_URL
       }
     })
 
@@ -610,10 +610,10 @@ async function ask () {
 
 async function processUpload (args, opts = { private: false, ask: false }) {
   try {
-    const authToken = await authenticate(args['upload-url'])
+    const authToken = await authenticate(args.server)
     const { email } = jwt.decode(authToken)
     console.log(`Signed in as ${email}.`)
-    const uploadURL = args['upload-url']
+    const uploadURL = args.server
 
     const results = []
     for (let i = 0; i < args._.length; i++) {
@@ -644,8 +644,8 @@ async function processUpload (args, opts = { private: false, ask: false }) {
     }
   } catch (err) {
     if (err.code === 'ECONNREFUSED') {
-      console.error(`Connection refused to the Upload Server at ${args['upload-url']}.`)
-      if (/localhost/.test(args['upload-url'])) {
+      console.error(`Connection refused to the Upload Server at ${args.server}.`)
+      if (/localhost/.test(args.server)) {
         console.error('Make sure the data server is running.')
       }
     } else {

--- a/bin.js
+++ b/bin.js
@@ -136,7 +136,7 @@ const result = commist()
         console.log('Logged out from all servers')
       })
     } else {
-      authenticate.logout(url).then(() => {
+      authenticate.logout(args['upload-url']).then(() => {
         console.log('Logged out from ', args['upload-url'])
       })
     }

--- a/bin.js
+++ b/bin.js
@@ -118,6 +118,9 @@ const result = commist()
       string: [
         'upload-url'
       ],
+      boolean: [
+        'all'
+      ],
       default: {
         'upload-url': DEFAULT_UPLOAD_URL
       }
@@ -128,9 +131,15 @@ const result = commist()
       process.exit(0)
     }
 
-    authenticate.logout(args['upload-url']).then(() => {
-      console.log('Logged out from ', args['upload-url'])
-    })
+    if (args.all) {
+      authenticate.removeSessions().then(() => {
+        console.log('Logged out from all servers')
+      })
+    } else {
+      authenticate.logout(url).then(() => {
+        console.log('Logged out from ', args['upload-url'])
+      })
+    }
   })
   .register('upload', function (argv) {
     const args = minimist(argv, {

--- a/bin.js
+++ b/bin.js
@@ -87,6 +87,9 @@ const result = commist()
           printUser(users[url])
           console.log('')
         })
+      }).catch((err) => {
+        console.error('Could not list sessions:', err.message)
+        process.exit(1)
       })
     }
   })
@@ -144,10 +147,16 @@ const result = commist()
     if (args.all) {
       authenticate.removeSessions().then(() => {
         console.log('Signed out from all servers')
+      }).catch((err) => {
+        console.error('Could not sign out:', err.message)
+        process.exit(1)
       })
     } else {
       authenticate.logout(args.server).then(() => {
         console.log('Signed out from ', args.server)
+      }).catch((err) => {
+        console.error('Could not sign out:', err.message)
+        process.exit(1)
       })
     }
   })

--- a/bin.js
+++ b/bin.js
@@ -657,6 +657,10 @@ async function processUpload (args, opts = { private: false, ask: false }) {
       if (/localhost/.test(args.server)) {
         console.error('Make sure the data server is running.')
       }
+    } else if (err.reply && err.reply.statusCode === 401 && !opts.retried) {
+      console.error('Authentication failure, your token might be expired. Retrying...')
+      await authenticate.logout(args.server)
+      return processUpload(args, Object.assign({}, opts, { retried: true }))
     } else {
       console.error('Unexpected Error:', err.stack)
     }

--- a/bin.js
+++ b/bin.js
@@ -61,6 +61,23 @@ const result = commist()
       console.log('Logged in as', header.name)
     })
   })
+  .register('logout', function (argv) {
+    const args = minimist(argv, {
+      alias: {
+        help: 'h'
+      },
+      string: [
+        'upload-url'
+      ],
+      default: {
+        'upload-url': DEFAULT_UPLOAD_URL
+      }
+    })
+
+    authenticate.logout(args['upload-url']).then(() => {
+      console.log('Logged out from ', args['upload-url'])
+    })
+  })
   .register('upload', function (argv) {
     const args = minimist(argv, {
       alias: {

--- a/bin.js
+++ b/bin.js
@@ -43,6 +43,24 @@ if ('NO_INSIGHT' in process.env) {
 checkForUpdates()
 
 const result = commist()
+  .register('login', function (argv) {
+    const args = minimist(argv, {
+      alias: {
+        help: 'h'
+      },
+      string: [
+        'upload-url'
+      ],
+      default: {
+        'upload-url': DEFAULT_UPLOAD_URL
+      }
+    })
+
+    authenticate(args['upload-url']).then((authToken) => {
+      const header = jwt.decode(authToken)
+      console.log('Logged in as', header.name)
+    })
+  })
   .register('upload', function (argv) {
     const args = minimist(argv, {
       alias: {

--- a/docs/clinic-login.txt
+++ b/docs/clinic-login.txt
@@ -5,7 +5,7 @@
 
   <h1>Flags</h1>
   -h | --help                Display Help
-  --upload-url               Specify a custom URL to a Clinic Upload server.
+  --server                   Specify a custom URL to a Clinic Upload server.
 
   <h1>Environment Variables</h1>
   CLINIC_JWT                 Token for authentication with the Clinic Upload server.

--- a/docs/clinic-login.txt
+++ b/docs/clinic-login.txt
@@ -1,0 +1,13 @@
+
+  <title>Clinic Login</title>
+
+  Log in to the Clinic Upload server.
+
+  <h1>Flags</h1>
+  -h | --help                Display Help
+  --upload-url               Specify a custom URL to a Clinic Upload server.
+
+  <h1>Environment Variables</h1>
+  CLINIC_JWT                 Token for authentication with the Clinic Upload server.
+                             Obtained from <link>https://upload.clinicjs.org/profile</link>.
+

--- a/docs/clinic-logout.txt
+++ b/docs/clinic-logout.txt
@@ -5,6 +5,6 @@
 
   <h1>Flags</h1>
   -h | --help                Display Help
-  --upload-url               Specify a custom URL to a Clinic Upload server.
+  --server                   Specify a custom URL to a Clinic Upload server.
   --all                      Log out of all Clinic Upload servers.
 

--- a/docs/clinic-logout.txt
+++ b/docs/clinic-logout.txt
@@ -1,0 +1,9 @@
+
+  <title>Clinic Logout</title>
+
+  Log out of the Clinic Upload server.
+
+  <h1>Flags</h1>
+  -h | --help                Display Help
+  --upload-url               Specify a custom URL to a Clinic Upload server.
+

--- a/docs/clinic-logout.txt
+++ b/docs/clinic-logout.txt
@@ -6,4 +6,5 @@
   <h1>Flags</h1>
   -h | --help                Display Help
   --upload-url               Specify a custom URL to a Clinic Upload server.
+  --all                      Log out of all Clinic Upload servers.
 

--- a/docs/clinic-upload.txt
+++ b/docs/clinic-upload.txt
@@ -27,6 +27,7 @@
   <h1>Flags</h1>
   -h | --help                Display Help
   --private                  Upload data privately to your account.
+  --server                   Upload data to a different Clinic Upload server.
 
   <h1>Environment Variables</h1>
   CLINIC_JWT                 Token for authentication with the Clinic Upload server.

--- a/docs/clinic-user.txt
+++ b/docs/clinic-user.txt
@@ -1,0 +1,12 @@
+
+  <title>Clinic User</title>
+
+  Show information for the currently logged-in user.
+
+  Provide <code>--upload-url</code> to show information for a specific Clinic Upload server.
+  If not provided, the information for all servers is listed.
+
+  <h1>Flags</h1>
+  -h | --help                Display Help
+  --upload-url               Display the user info for this Clinic Upload server only.
+

--- a/docs/clinic-user.txt
+++ b/docs/clinic-user.txt
@@ -3,10 +3,10 @@
 
   Show information for the currently logged-in user.
 
-  Provide <code>--upload-url</code> to show information for a specific Clinic Upload server.
+  Provide <code>--server</code> to show information for a specific Clinic Upload server.
   If not provided, the information for all servers is listed.
 
   <h1>Flags</h1>
   -h | --help                Display Help
-  --upload-url               Display the user info for this Clinic Upload server only.
+  --server                   Display the user info for this Clinic Upload server only.
 

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -27,6 +27,22 @@ async function loadToken (url) {
   return tokens && tokens[url]
 }
 
+function validateToken (token) {
+  const header = jwt.decode(token)
+  const now = Math.floor(Date.now() / 1000)
+  return header && header.exp > now
+}
+
+async function getSession (url) {
+  const token = await loadToken(url)
+  if (!token) return null
+  const header = jwt.decode(token)
+  if (!header) return null
+  const now = Math.floor(Date.now() / 1000)
+  if (header.exp <= now) return null
+  return header
+}
+
 async function saveToken (url, token) {
   let tokens
   try {
@@ -98,11 +114,8 @@ async function authenticate (url) {
   // Use cached token if it's not expired
   try {
     const existingJWT = await loadToken(url)
-    if (existingJWT) {
-      const header = jwt.decode(existingJWT)
-      if (header && header.exp > Math.floor(Date.now() / 1000)) {
-        return existingJWT
-      }
+    if (existingJWT && validateToken(existingJWT)) {
+      return existingJWT
     }
   } catch (err) {}
 
@@ -111,9 +124,26 @@ async function authenticate (url) {
   return newJWT
 }
 
+async function getSessions () {
+  let tokens
+  try {
+    const data = await readFile(credentialsPath)
+    tokens = JSON.parse(data)
+  } catch (err) {}
+  const sessions = {}
+  Object.keys(tokens).forEach((url) => {
+    sessions[url] = validateToken(tokens[url])
+      ? jwt.decode(tokens[url])
+      : null
+  })
+  return sessions
+}
+
 function logout (url) {
   return saveToken(url, undefined)
 }
 
 module.exports = authenticate
+module.exports.getSessions = getSessions
+module.exports.getSession = getSession
 module.exports.logout = logout

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -11,6 +11,7 @@ const split2 = require('split2')
 const { ReadableStreamBuffer } = require('stream-buffers')
 const { URL } = require('url')
 const pump = require('pump')
+const jwt = require('jsonwebtoken')
 
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
@@ -94,11 +95,14 @@ async function authenticate (url) {
     throw new Error('Auth artificially failed')
   }
 
+  // Use cached token if it's not expired
   try {
     const existingJWT = await loadToken(url)
     if (existingJWT) {
-      console.log('TODO validate', { existingJWT })
-      return existingJWT
+      const header = jwt.decode(existingJWT)
+      if (header && header.exp > Math.floor(Date.now() / 1000)) {
+        return existingJWT
+      }
     }
   } catch (err) {}
 

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -111,4 +111,9 @@ async function authenticate (url) {
   return newJWT
 }
 
+function logout (url) {
+  return saveToken(url, undefined)
+}
+
 module.exports = authenticate
+module.exports.logout = logout

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -119,6 +119,7 @@ async function authenticate (url) {
   const mockJWT = process.env.CLINIC_JWT
   const mockFail = process.env.CLINIC_MOCK_AUTH_FAIL
   if (mockJWT) {
+    await saveToken(url, mockJWT)
     return mockJWT
   }
   if (mockFail) {

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -17,8 +17,12 @@ const unlink = promisify(fs.unlink)
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
 
-const credentialsPath = path.join(homedir(), '.node-clinic-rc')
+const credentialsPath = process.env.CLINIC_CREDENTIALS
+  || path.join(homedir(), '.node-clinic-rc')
 
+/**
+ * Load the JWT for an Upload Server URL.
+ */
 async function loadToken (url) {
   let tokens
   try {
@@ -28,12 +32,18 @@ async function loadToken (url) {
   return tokens && tokens[url]
 }
 
+/**
+ * Check that a JWT has not expired.
+ */
 function validateToken (token) {
   const header = jwt.decode(token)
   const now = Math.floor(Date.now() / 1000)
   return header && header.exp > now
 }
 
+/**
+ * Get the session data for an Upload Server URL.
+ */
 async function getSession (url) {
   const token = await loadToken(url)
   if (!token) return null
@@ -44,6 +54,9 @@ async function getSession (url) {
   return header
 }
 
+/**
+ * Store the JWT for an Upload Server URL in the credentials file.
+ */
 async function saveToken (url, token) {
   let tokens
   try {
@@ -126,7 +139,7 @@ async function authenticate (url) {
 }
 
 async function getSessions () {
-  let tokens
+  let tokens = {}
   try {
     const data = await readFile(credentialsPath)
     tokens = JSON.parse(data)

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -17,8 +17,8 @@ const unlink = promisify(fs.unlink)
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
 
-const credentialsPath = process.env.CLINIC_CREDENTIALS
-  || path.join(homedir(), '.node-clinic-rc')
+const credentialsPath = process.env.CLINIC_CREDENTIALS ||
+  path.join(homedir(), '.node-clinic-rc')
 
 /**
  * Load the JWT for an Upload Server URL.

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -13,6 +13,7 @@ const { URL } = require('url')
 const pump = require('pump')
 const jwt = require('jsonwebtoken')
 
+const unlink = promisify(fs.unlink)
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
 
@@ -143,7 +144,12 @@ function logout (url) {
   return saveToken(url, undefined)
 }
 
+function removeSessions () {
+  return unlink(credentialsPath)
+}
+
 module.exports = authenticate
 module.exports.getSessions = getSessions
 module.exports.getSession = getSession
+module.exports.removeSessions = removeSessions
 module.exports.logout = logout

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -127,12 +127,10 @@ async function authenticate (url) {
   }
 
   // Use cached token if it's not expired
-  try {
-    const existingJWT = await loadToken(url)
-    if (existingJWT && validateToken(existingJWT)) {
-      return existingJWT
-    }
-  } catch (err) {}
+  const existingJWT = await loadToken(url)
+  if (existingJWT && validateToken(existingJWT)) {
+    return existingJWT
+  }
 
   const newJWT = await authenticateViaBrowser(url)
   await saveToken(url, newJWT)

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -119,7 +119,12 @@ async function authenticate (url) {
   const mockJWT = process.env.CLINIC_JWT
   const mockFail = process.env.CLINIC_MOCK_AUTH_FAIL
   if (mockJWT) {
-    await saveToken(url, mockJWT)
+    // store it if we ALSO specified a credentials file,
+    // Normally, you shouldn't use both CLINIC_JWT and CLINIC_CREDENTIALS at the same time,
+    // but this is a useful case for our tests
+    if (process.env.CLINIC_CREDENTIALS) {
+      await saveToken(url, mockJWT)
+    }
     return mockJWT
   }
   if (mockFail) {

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -1,12 +1,47 @@
 'use strict'
 
 const opn = require('opn')
+const path = require('path')
+const fs = require('fs')
+const { promisify } = require('util')
+const { homedir } = require('os')
 const randtoken = require('rand-token')
 const websocket = require('websocket-stream')
 const split2 = require('split2')
 const { ReadableStreamBuffer } = require('stream-buffers')
 const { URL } = require('url')
 const pump = require('pump')
+
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+
+const credentialsPath = path.join(homedir(), '.node-clinic-rc')
+
+async function loadToken (url) {
+  let tokens
+  try {
+    const data = await readFile(credentialsPath)
+    tokens = JSON.parse(data)
+  } catch (err) {}
+  return tokens && tokens[url]
+}
+
+async function saveToken (url, token) {
+  let tokens
+  try {
+    const data = await readFile(credentialsPath)
+    tokens = JSON.parse(data)
+  } catch (err) {}
+
+  // if it was empty or contained `null` for some reason
+  if (typeof tokens !== 'object' || !tokens) {
+    tokens = {}
+  }
+
+  tokens[url] = token
+
+  await writeFile(credentialsPath, JSON.stringify(tokens, null, 2))
+}
 
 /**
  * Get the JWT token from the Upload server specified by the URL.
@@ -16,17 +51,8 @@ const pump = require('pump')
  * - Open the browser on `http://localhost:3000/?token=${cliToken}`
  * - Get the JWT from the web websocket
  */
-const authenticate = url =>
-  new Promise((resolve, reject) => {
-    const mockJWT = process.env.CLINIC_JWT
-    const mockFail = process.env.CLINIC_MOCK_AUTH_FAIL
-    if (mockJWT) {
-      return resolve(mockJWT)
-    }
-    if (mockFail) {
-      return reject(new Error('Auth artificially failed'))
-    }
-
+function authenticateViaBrowser (url) {
+  return new Promise((resolve, reject) => {
     const cliToken = randtoken.generate(128)
     const parsedURL = new URL(url)
     /* istanbul ignore next */
@@ -56,5 +82,29 @@ const authenticate = url =>
       opn(cliLoginUrl, { wait: false })
     })
   })
+}
+
+async function authenticate (url) {
+  const mockJWT = process.env.CLINIC_JWT
+  const mockFail = process.env.CLINIC_MOCK_AUTH_FAIL
+  if (mockJWT) {
+    return mockJWT
+  }
+  if (mockFail) {
+    throw new Error('Auth artificially failed')
+  }
+
+  try {
+    const existingJWT = await loadToken(url)
+    if (existingJWT) {
+      console.log('TODO validate', { existingJWT })
+      return existingJWT
+    }
+  } catch (err) {}
+
+  const newJWT = await authenticateViaBrowser(url)
+  await saveToken(url, newJWT)
+  return newJWT
+}
 
 module.exports = authenticate

--- a/lib/tar-and-upload.js
+++ b/lib/tar-and-upload.js
@@ -67,7 +67,11 @@ function tarAndUpload (filePrefix, uploadUrl, authToken, opts, cb) {
   function onupload (err, res, body) {
     if (err) return cb(err)
     if (!/^2\d\d$/.test(res.statusCode)) {
-      return cb(new Error('Bad status code: ' + res.statusCode))
+      var error = new Error('Bad status code: ' + res.statusCode)
+      try {
+        error.reply = JSON.parse(body)
+      } catch (err) {}
+      return cb(error)
     }
     try {
       var reply = JSON.parse(body)

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "standard": "^12.0.0",
     "tap": "^12.1.0",
     "tap-junit": "^2.1.0",
-    "tar-stream": "^1.6.2"
+    "tar-stream": "^1.6.2",
+    "tmp": "0.0.33"
   },
   "keywords": [
     "performance",

--- a/test/cli-ask-full.test.js
+++ b/test/cli-ask-full.test.js
@@ -29,7 +29,7 @@ test('clinic ask 10000.clinic-doctor with custom upload url', function (t) {
     env: { CLINIC_JWT: successfulJwt }
   }, [
     'clinic', 'ask',
-    '--upload-url', server.uploadUrl,
+    '--server', server.uploadUrl,
     doctorADirectory
   ], function (err, stdout) {
     t.plan(3)
@@ -79,7 +79,7 @@ test('clinic ask 10000.clinic-doctor auth failure', function (t) {
     env: { CLINIC_MOCK_AUTH_FAIL: 'true' }
   }, [
     'clinic', 'ask',
-    '--upload-url', server.uploadUrl,
+    '--server', server.uploadUrl,
     doctorADirectory
   ], function (err, stdout, stderr) {
     t.plan(2)

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -195,10 +195,10 @@ test('clinic logout --all logs out of all servers', function (t) {
         checkLogin(server.uploadUrl, (err, stdout) => {
           t.ok(err)
           t.ok(/Not authenticated/.test(stdout))
-        })
-        checkLogin(server2.uploadUrl, (err, stdout) => {
-          t.ok(err)
-          t.ok(/Not authenticated/.test(stdout))
+          checkLogin(server2.uploadUrl, (err, stdout) => {
+            t.ok(err)
+            t.ok(/Not authenticated/.test(stdout))
+          })
         })
       })
     })

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -167,7 +167,7 @@ test('clinic logout', function (t) {
   function checkLogin (cb) {
     cli({
       env: {
-        CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout'),
+        CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout')
       }
     }, [ 'clinic', 'user', '--upload-url', server.uploadUrl ], cb)
   }
@@ -214,7 +214,7 @@ test('clinic logout --all logs out of all servers', function (t) {
   function checkLogin (url, cb) {
     cli({
       env: {
-        CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout-all'),
+        CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout-all')
       }
     }, [ 'clinic', 'user', '--upload-url', url ], cb)
   }

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const test = require('tap').test
+const path = require('path')
+const tmp = require('tmp')
+const cli = require('./cli.js')
+const FakeUploadServer = require('./fake-upload-server.js')
+let server
+let tempCredentials
+
+// JWT containing test@test.com
+const successfulJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NDIyMjI5MzMsImV4cCI6MTg4OTM3ODEzMywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoidGVzdCIsImVtYWlsIjoidGVzdEB0ZXN0LmNvbSJ9.FO0v4OM2V23lAXIcv-qcfFo0snOrOmsrY82kmcYlrJI'
+
+test('Before all', function (t) {
+  tempCredentials = tmp.dirSync()
+  server = new FakeUploadServer()
+  server.listen(function () {
+    t.plan(1)
+    t.ok(server)
+  })
+})
+
+test('clinic login', function (t) {
+  cli({
+    env: {
+      CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-login'),
+      CLINIC_JWT: successfulJwt
+    }
+  }, [
+    'clinic', 'login',
+    '--upload-url', server.uploadUrl
+  ], function (err, stdout) {
+    t.plan(2)
+    t.ifError(err)
+
+    t.strictDeepEqual(stdout.trim().split('\n'), [
+      'Signed in as test@test.com.'
+    ])
+  })
+})
+
+test('clinic user exits with 1 if not authenticated', function (t) {
+  cli({
+    env: {
+      CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user')
+    }
+  }, [
+    'clinic', 'user'
+  ], function (err, stdout) {
+    t.plan(2)
+    t.ok(err)
+    t.ok(/exited with exit code 1/.test(err.message))
+  })
+})
+
+test('clinic user lists all authed users', function (t) {
+  t.plan(3)
+
+  cli({
+    env: {
+      CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user-all'),
+      CLINIC_JWT: successfulJwt
+    }
+  }, [
+    'clinic', 'login',
+    '--upload-url', server.uploadUrl
+  ], function (err) {
+    t.ifError(err)
+    cli({
+      env: {
+        CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user-all')
+      }
+    }, [
+      'clinic', 'user'
+    ], function (err, stdout) {
+      t.ifError(err)
+      t.ok(stdout)
+    })
+  })
+})
+
+test('After all', function (t) {
+  t.plan(0)
+  server.close()
+  tempCredentials.removeCallback()
+})

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -98,17 +98,10 @@ test('clinic user lists all authed users', function (t) {
       'clinic', 'user'
     ], function (err, stdout) {
       t.ifError(err)
-      const userInfos = stdout.split('\n\n')
-        .filter((el) => el !== '')
-        .sort((a, b) => {
-          if (a.includes('test@test')) return -1
-          if (a.includes('other@email')) return 1
-          return 0
-        })
-      t.ok(userInfos[0].includes(server.uploadUrl))
-      t.ok(userInfos[0].includes('Authenticated as test@test.com.'))
-      t.ok(userInfos[1].includes(server2.uploadUrl))
-      t.ok(userInfos[1].includes('Authenticated as other@email.com.'))
+      t.ok(stdout.includes(server.uploadUrl))
+      t.ok(stdout.includes('Authenticated as test@test.com.'))
+      t.ok(stdout.includes(server2.uploadUrl))
+      t.ok(stdout.includes('Authenticated as other@email.com.'))
     })
   }
 })

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -35,7 +35,7 @@ test('clinic login', function (t) {
     }
   }, [
     'clinic', 'login',
-    '--upload-url', server.uploadUrl
+    '--server', server.uploadUrl
   ], function (err, stdout) {
     t.plan(2)
     t.ifError(err)
@@ -72,7 +72,7 @@ test('clinic user lists all authed users', function (t) {
     }
   }, [
     'clinic', 'login',
-    '--upload-url', server.uploadUrl
+    '--server', server.uploadUrl
   ], next)
 
   cli({
@@ -82,7 +82,7 @@ test('clinic user lists all authed users', function (t) {
     }
   }, [
     'clinic', 'login',
-    '--upload-url', server2.uploadUrl
+    '--server', server2.uploadUrl
   ], next)
 
   function next (err) {
@@ -113,7 +113,7 @@ test('clinic user lists all authed users', function (t) {
   }
 })
 
-test('clinic user --upload-url lists single user', function (t) {
+test('clinic user --server lists single user', function (t) {
   t.plan(3)
 
   cli({
@@ -123,7 +123,7 @@ test('clinic user --upload-url lists single user', function (t) {
     }
   }, [
     'clinic', 'login',
-    '--upload-url', server.uploadUrl
+    '--server', server.uploadUrl
   ], function (err) {
     t.ifError(err)
 
@@ -163,7 +163,7 @@ test('clinic logout', function (t) {
         CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout'),
         CLINIC_JWT: successfulJwt
       }
-    }, [ 'clinic', 'login', '--upload-url', server.uploadUrl ], cb)
+    }, [ 'clinic', 'login', '--server', server.uploadUrl ], cb)
   }
 
   function checkLogin (cb) {
@@ -171,7 +171,7 @@ test('clinic logout', function (t) {
       env: {
         CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout')
       }
-    }, [ 'clinic', 'user', '--upload-url', server.uploadUrl ], cb)
+    }, [ 'clinic', 'user', '--server', server.uploadUrl ], cb)
   }
 
   function logout (cb) {
@@ -179,7 +179,7 @@ test('clinic logout', function (t) {
       env: {
         CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout')
       }
-    }, [ 'clinic', 'logout', '--upload-url', server.uploadUrl ], cb)
+    }, [ 'clinic', 'logout', '--server', server.uploadUrl ], cb)
   }
 })
 
@@ -210,7 +210,7 @@ test('clinic logout --all logs out of all servers', function (t) {
         CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout-all'),
         CLINIC_JWT: token
       }
-    }, [ 'clinic', 'login', '--upload-url', url ], cb)
+    }, [ 'clinic', 'login', '--server', url ], cb)
   }
 
   function checkLogin (url, cb) {
@@ -218,7 +218,7 @@ test('clinic logout --all logs out of all servers', function (t) {
       env: {
         CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-logout-all')
       }
-    }, [ 'clinic', 'user', '--upload-url', url ], cb)
+    }, [ 'clinic', 'user', '--server', url ], cb)
   }
 
   function logoutAll (cb) {

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -6,17 +6,24 @@ const tmp = require('tmp')
 const cli = require('./cli.js')
 const FakeUploadServer = require('./fake-upload-server.js')
 let server
+let server2
 let tempCredentials
 
 // JWT containing test@test.com
 const successfulJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NDIyMjI5MzMsImV4cCI6MTg4OTM3ODEzMywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoidGVzdCIsImVtYWlsIjoidGVzdEB0ZXN0LmNvbSJ9.FO0v4OM2V23lAXIcv-qcfFo0snOrOmsrY82kmcYlrJI'
+// JWT containing other@email.com
+const successfulJwt2 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NDcwNDQwOTIsImV4cCI6MTg2MjY2MzI5MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiYmx1YiIsImVtYWlsIjoib3RoZXJAZW1haWwuY29tIn0.4OO5_5P3tEf-2Ggq9wmWWFGXM9p1NGmBnWX5bfCLVxE'
 
 test('Before all', function (t) {
+  t.plan(2)
   tempCredentials = tmp.dirSync()
   server = new FakeUploadServer()
   server.listen(function () {
-    t.plan(1)
     t.ok(server)
+  })
+  server2 = new FakeUploadServer()
+  server2.listen(function () {
+    t.ok(server2)
   })
 })
 
@@ -54,7 +61,9 @@ test('clinic user exits with 1 if not authenticated', function (t) {
 })
 
 test('clinic user lists all authed users', function (t) {
-  t.plan(3)
+  t.plan(7)
+
+  let after = 2
 
   cli({
     env: {
@@ -64,8 +73,23 @@ test('clinic user lists all authed users', function (t) {
   }, [
     'clinic', 'login',
     '--upload-url', server.uploadUrl
-  ], function (err) {
+  ], next)
+
+  cli({
+    env: {
+      CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user-all'),
+      CLINIC_JWT: successfulJwt2
+    }
+  }, [
+    'clinic', 'login',
+    '--upload-url', server2.uploadUrl
+  ], next)
+
+  function next (err) {
     t.ifError(err)
+    after -= 1
+    if (after > 0) return
+
     cli({
       env: {
         CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user-all')
@@ -74,7 +98,42 @@ test('clinic user lists all authed users', function (t) {
       'clinic', 'user'
     ], function (err, stdout) {
       t.ifError(err)
-      t.ok(stdout)
+      const userInfos = stdout.split('\n\n').sort((a, b) => {
+        if (a.includes('test@test')) return -1
+        if (a.includes('other@email')) return 1
+        return 0
+      })
+      t.ok(userInfos[0].includes(server.uploadUrl))
+      t.ok(userInfos[0].includes('Authenticated as test@test.com.'))
+      t.ok(userInfos[1].includes(server2.uploadUrl))
+      t.ok(userInfos[1].includes('Authenticated as other@email.com.'))
+    })
+  }
+})
+
+test('clinic user --upload-url lists single user', function (t) {
+  t.plan(3)
+
+  cli({
+    env: {
+      CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user-one'),
+      CLINIC_JWT: successfulJwt
+    }
+  }, [
+    'clinic', 'login',
+    '--upload-url', server.uploadUrl
+  ], function (err) {
+    t.ifError(err)
+
+    cli({
+      env: {
+        CLINIC_CREDENTIALS: path.join(tempCredentials.name, '.clinic-user-one')
+      }
+    }, [
+      'clinic', 'user'
+    ], function (err, stdout) {
+      t.ifError(err)
+      t.ok(stdout.includes('Authenticated as test@test.com.'))
     })
   })
 })
@@ -82,5 +141,5 @@ test('clinic user lists all authed users', function (t) {
 test('After all', function (t) {
   t.plan(0)
   server.close()
-  tempCredentials.removeCallback()
+  server2.close()
 })

--- a/test/cli-login-logout.test.js
+++ b/test/cli-login-logout.test.js
@@ -98,11 +98,13 @@ test('clinic user lists all authed users', function (t) {
       'clinic', 'user'
     ], function (err, stdout) {
       t.ifError(err)
-      const userInfos = stdout.split('\n\n').sort((a, b) => {
-        if (a.includes('test@test')) return -1
-        if (a.includes('other@email')) return 1
-        return 0
-      })
+      const userInfos = stdout.split('\n\n')
+        .filter((el) => el !== '')
+        .sort((a, b) => {
+          if (a.includes('test@test')) return -1
+          if (a.includes('other@email')) return 1
+          return 0
+        })
       t.ok(userInfos[0].includes(server.uploadUrl))
       t.ok(userInfos[0].includes('Authenticated as test@test.com.'))
       t.ok(userInfos[1].includes(server2.uploadUrl))

--- a/test/cli-upload-files.test.js
+++ b/test/cli-upload-files.test.js
@@ -37,7 +37,7 @@ test('clinic upload 10000.clinic-doctor', function (t) {
       env: { CLINIC_JWT: successfulJwt }
     }, [
       'clinic', 'upload',
-      '--upload-url', server.uploadUrl,
+      '--server', server.uploadUrl,
       doctorADirectory
     ], function (err, stdout) {
       t.ifError(err)
@@ -73,7 +73,7 @@ test('clinic upload 10000.clinic-doctor privately', function (t) {
     }, [
       'clinic', 'upload',
       '--private',
-      '--upload-url', server.uploadUrl,
+      '--server', server.uploadUrl,
       doctorADirectory
     ], function (err, stdout) {
       t.ifError(err)
@@ -107,7 +107,7 @@ test('clinic upload 10000.clinic-doctor 10001.clinic-doctor', function (t) {
       env: { CLINIC_JWT: successfulJwt }
     }, [
       'clinic', 'upload',
-      '--upload-url', server.uploadUrl,
+      '--server', server.uploadUrl,
       doctorADirectory, doctorBDirectory
     ], function (err, stdout) {
       t.ifError(err)
@@ -156,7 +156,7 @@ test('clinic upload - bad status code', function (t) {
       relayStderr: false
     }, [
       'clinic', 'upload',
-      '--upload-url', `http://127.0.0.1:${server.address().port}`,
+      '--server', `http://127.0.0.1:${server.address().port}`,
       doctorADirectory
     ], function (err, stdout, stderr) {
       t.strictDeepEqual(err, new Error('process exited with exit code 1'))
@@ -178,7 +178,7 @@ test('clinic upload bad-folder', function (t) {
       relayStderr: false
     }, [
       'clinic', 'upload',
-      '--upload-url', server.uploadUrl,
+      '--server', server.uploadUrl,
       doctorBadDirectory
     ], function (err, stdout, stderr) {
       t.strictDeepEqual(err, new Error('process exited with exit code 1'))


### PR DESCRIPTION
Stores the JWT in ~/.node-clinic-rc after logging in. ~/.node-clinic-rc is a JSON file with upload URLs as keys, JWTs as values.

Use `clinic login` to login manually. Optionally specify an `--upload-url`.
Use `clinic logout` to logout manually. Optionally specify an `--upload-url`. Add `--all` to log out of all Clinic Upload servers, this deletes the ~/.node-clinic-rc file.
Use `clinic user` to show a list of current sessions. Optionally specify an `--upload-url` to only show that session.

You can use the `CLINIC_CREDENTIALS` environment variable to point to a different file. I added this for tests, maybe it's also useful in programmatic environments and warrants docs?

`clinic upload` and `clinic ask` automatically do what `clinic login` does at the start.

TODO:
 - [x] Right now if you specify CLINIC_JWT it is also stored in the cache file. This is helpful for testing the cache but it's probably not ideal in a programmatic environment, maybe it should not be stored by default but only if a custom CLINIC_CREDENTIALS path is also specified.
 - [x] Reauth in `upload` and `ask` if we had a non-expired JWT that is not accepted by the server for some reason. Can do this by discarding the token and starting over.