### PR TITLE
Ignore unfixable issue in nested dep `chownr`, from unused feature of `tar-fs`

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.3
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-CHOWNR-73502:
+    - tar-fs > chownr:
+        reason: vulnerability is in a feature we don't use (tar-fs "own" option), is only a problem on a system that is already compromised, and is considered unfixable (inherent to that type of operation) https://github.com/isaacs/chownr/issues/14#issuecomment-451543037
+        expires: '2019-05-01T22:22:22.123Z'
+patch: {}


### PR DESCRIPTION
Snyk is flagging this (now-public) low severity issue - but it doesn't affect us:

> ✗ Low severity vuln found in chownr@1.1.1, introduced via tar-fs@1.16.3
>     Description: Time of Check Time of Use (TOCTOU)
>     Info: https://snyk.io/vuln/SNYK-JS-CHOWNR-73502
>     From: tar-fs@1.16.3 > chownr@1.1.1

`chownr` is a dependency of `tar-fs`, which we use to bundle tars to upload (and most tar-fs alternatives). `tar-fs` only uses `chownr` in its `extract` method, if an option is passed. We don't use tar-fs's `extract`, we only use `pack`.  

Even if we did, the vulnerability in `chownr` is inherent to any recursive chown or chmod or similar. See https://github.com/isaacs/chownr/issues/14#issuecomment-451543037 -

> ...there is no atomic way to verify that, at the exact time of readding a directory, it's a real directory and not a symlink to somewhere else.
> 
> That being the case there will always be a TOCTOU issue for any recursive filesystem operation that traverses directories making changes at each level. No exceptions. The same TOCTOU issue exists for `chown -r`, `rm -rf`, `chmod -r`, etc.

...and it's only an issue on a system that is already compromised:

> ...it requires an attacker having access to the filesystem where the user script is running chown, and in that case, this TOCTOU is the least of your worries.

So it seems reasonable to ignore it. 

I'm setting it to be revisited in May 2019 because by then the way we use tar-fs may have changed due to adding validation, and I suspect Snyk might reclassify this issue.