### PR TITLE
Ensure landing page is mocked in GA

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -59,6 +59,7 @@ const result = commist()
       printHelp('clinic-upload')
     } else if (args._.length > 0) {
       checkMetricsPermission(() => {
+        insight.track('upload', 'public')
         insight.trackEvent({
           category: 'upload',
           action: 'public'
@@ -271,6 +272,7 @@ function trackTool (toolName, args, toolVersion, cb) {
   }
 
   checkMetricsPermission(() => {
+    insight.track(toolName, action)
     insight.trackEvent({
       category: toolName,
       action,


### PR DESCRIPTION
This will set the following 'landing pages' in GA:

```
clinic upload => /upload/public

clinic doctor                        => /doctor/run
clinic doctor ----visualize-only     => /doctor/visualize-only
clinic doctor ----collect-only       => /doctor/collect-only

clinic bubbleprof                    => /bubbleprof/run
clinic bubbleprof ----visualize-only => /bubbleprof/visualize-only
clinic bubbleprof ----collect-only   => /bubbleprof/collect-only

clinic flame                         => /flame/run
clinic flame ----visualize-only      => /flame/visualize-only
clinic flame ----collect-only        => /flame/collect-only
```