### PR TITLE
Feature/ask auth flag

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -619,7 +619,7 @@ async function ask () {
 
 async function processUpload (args, opts = { private: false, ask: false }) {
   try {
-    const authToken = await authenticate(args.server)
+    const authToken = await authenticate(args.server, opts.ask)
     const { email } = jwt.decode(authToken)
     console.log(`Signed in as ${email}.`)
     const uploadURL = args.server

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -20,6 +20,9 @@ const writeFile = promisify(fs.writeFile)
 const credentialsPath = process.env.CLINIC_CREDENTIALS ||
   path.join(homedir(), '.node-clinic-rc')
 
+const CUSTOM_CLAIM_NAMESPACE = 'https://upload.clinicjs.org/'
+const ASK_CLAIM_KEY = `${CUSTOM_CLAIM_NAMESPACE}askTermsAccepted`
+
 /**
  * Load the JWT for an Upload Server URL.
  */
@@ -39,6 +42,15 @@ function validateToken (token) {
   const header = jwt.decode(token)
   const now = Math.floor(Date.now() / 1000)
   return header && header.exp > now
+}
+
+/**
+ * Check that a JWT has Ask terms accepted.
+ */
+function validateAskPermission (token) {
+  const header = jwt.decode(token)
+
+  return validateToken(token) && header[ASK_CLAIM_KEY]
 }
 
 /**
@@ -79,10 +91,10 @@ async function saveToken (url, token) {
  * - create a random tokens
  * - open a websocket on the server
  * - push the token through the websocket
- * - Open the browser on `http://localhost:3000/?token=${cliToken}(&ask=1)`
+ * - Open the browser on `http://localhost:3000/auth/token/${cliToken}/(?ask=1)`
  * - Get the JWT from the web websocket
  */
-function authenticateViaBrowser (url, isAskFlow = false) {
+function authenticateViaBrowser (url, isAskFlow = false, clearSession = false) {
   return new Promise((resolve, reject) => {
     const cliToken = randtoken.generate(128)
     const parsedURL = new URL(url)
@@ -109,7 +121,10 @@ function authenticateViaBrowser (url, isAskFlow = false) {
     ws.once('connect', () => {
       console.log('Authentication required. Opening the login page in a browser...')
       // Open the url in the default browser
-      const cliLoginUrl = `${url}?token=${cliToken}${isAskFlow ? '&ask=1' : ''}`
+      const cliLoginUrl = generateBrowserLoginUrl(url, cliToken, {
+        isAskFlow,
+        clearSession
+      })
       opn(cliLoginUrl, { wait: false })
     })
   })
@@ -133,11 +148,16 @@ async function authenticate (url, isAskFlow) {
 
   // Use cached token if it's not expired
   const existingJWT = await loadToken(url)
+  let clearSession = false
   if (existingJWT && validateToken(existingJWT)) {
-    return existingJWT
+    if (!isAskFlow || validateAskPermission(existingJWT)) {
+      return existingJWT
+    } else if (isAskFlow) {
+      clearSession = true
+    }
   }
 
-  const newJWT = await authenticateViaBrowser(url, isAskFlow)
+  const newJWT = await authenticateViaBrowser(url, isAskFlow, clearSession)
   await saveToken(url, newJWT)
   return newJWT
 }
@@ -163,6 +183,20 @@ function logout (url) {
 
 function removeSessions () {
   return unlink(credentialsPath)
+}
+
+function generateBrowserLoginUrl (base, token, opts = {}) {
+  const url = new URL(`${base}/auth/token/${token}/`)
+
+  if (opts.isAskFlow) {
+    url.searchParams.append('ask', '1')
+  }
+
+  if (opts.clearSession) {
+    url.searchParams.append('clearSession', '1')
+  }
+
+  return url.toString()
 }
 
 module.exports = authenticate

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -79,10 +79,10 @@ async function saveToken (url, token) {
  * - create a random tokens
  * - open a websocket on the server
  * - push the token through the websocket
- * - Open the browser on `http://localhost:3000/?token=${cliToken}`
+ * - Open the browser on `http://localhost:3000/?token=${cliToken}(&ask=1)`
  * - Get the JWT from the web websocket
  */
-function authenticateViaBrowser (url) {
+function authenticateViaBrowser (url, isAskFlow = false) {
   return new Promise((resolve, reject) => {
     const cliToken = randtoken.generate(128)
     const parsedURL = new URL(url)
@@ -109,13 +109,13 @@ function authenticateViaBrowser (url) {
     ws.once('connect', () => {
       console.log('Authentication required. Opening the login page in a browser...')
       // Open the url in the default browser
-      const cliLoginUrl = `${url}?token=${cliToken}`
+      const cliLoginUrl = `${url}?token=${cliToken}${isAskFlow ? '&ask=1' : ''}`
       opn(cliLoginUrl, { wait: false })
     })
   })
 }
 
-async function authenticate (url) {
+async function authenticate (url, isAskFlow) {
   const mockJWT = process.env.CLINIC_JWT
   const mockFail = process.env.CLINIC_MOCK_AUTH_FAIL
   if (mockJWT) {
@@ -137,7 +137,7 @@ async function authenticate (url) {
     return existingJWT
   }
 
-  const newJWT = await authenticateViaBrowser(url)
+  const newJWT = await authenticateViaBrowser(url, isAskFlow)
   await saveToken(url, newJWT)
   return newJWT
 }

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -41,7 +41,7 @@ test('authenticate', async function (t) {
 
   const jwtToken = await authenticate(`http://127.0.0.1:${server.address().port}`)
   t.plan(2)
-  t.strictEqual(openedUrl.split('token=')[1], cliToken)
+  t.strictEqual(openedUrl.split('/auth/token/')[1].replace('/', ''), cliToken)
   t.strictEqual(jwtToken, 'jwtToken')
 })
 
@@ -54,10 +54,10 @@ test('authenticate using ask', async function (t) {
   const authenticate = proxyquire('../lib/authenticate', { 'opn': opnStub }) // mocking the browser opening
 
   const jwtToken = await authenticate(`http://127.0.0.1:${server.address().port}`, true)
-  const [tokenQuery, askQuery] = openedUrl.split('?')[1].split('&').map(item => item.split('='))
+  const [token, askQuery] = openedUrl.split('/auth/token/')[1].split('?')
   t.plan(3)
-  t.strictEqual(tokenQuery[1], cliToken)
-  t.strictEqual(askQuery[1], '1')
+  t.strictEqual(token.replace('/', ''), cliToken)
+  t.strictEqual(askQuery, 'ask=1')
   t.strictEqual(jwtToken, 'jwtToken')
 })
 

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -45,6 +45,22 @@ test('authenticate', async function (t) {
   t.strictEqual(jwtToken, 'jwtToken')
 })
 
+test('authenticate using ask', async function (t) {
+  let openedUrl = ''
+  const opnStub = url => {
+    openedUrl = url
+  }
+
+  const authenticate = proxyquire('../lib/authenticate', { 'opn': opnStub }) // mocking the browser opening
+
+  const jwtToken = await authenticate(`http://127.0.0.1:${server.address().port}`, true)
+  const [tokenQuery, askQuery] = openedUrl.split('?')[1].split('&').map(item => item.split('='))
+  t.plan(3)
+  t.strictEqual(tokenQuery[1], cliToken)
+  t.strictEqual(askQuery[1], '1')
+  t.strictEqual(jwtToken, 'jwtToken')
+})
+
 test('authenticate timeout', async function (t) {
   const opnStub = url => url
 


### PR DESCRIPTION
## Overview
- Sends user through a specific consent during authentication form based on whether they use `clinic upload` or `clinic ask`
- Checks type of consent against the requested action when using stored token and forcing the user to re-authenticate if `ask` consent not given
