### PR TITLE
Remove unused tap-junit

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "snazzy": "^8.0.0",
     "standard": "^12.0.0",
     "tap": "^12.1.0",
-    "tap-junit": "^2.1.0",
     "tar-stream": "^1.6.2"
   },
   "keywords": [


### PR DESCRIPTION
This was used for a while during the configuration of Azure Pipelines,
but was removed in https://github.com/nearform/node-clinic/pull/93/commits/2179cd81b1f0fd329d38bf04be9ed16bc8df2689
before that PR was merged.

Closes #123