### PR TITLE
Test backslash-escaping $NOT_ENV_VARS in --autocannon URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-argv": "^1.0.0",
     "dargs": "^6.0.0",
     "dedent": "^0.7.0",
-    "env-string": "^1.0.0",
+    "env-string": "^1.0.1",
     "execspawn": "^1.0.1",
     "inquirer": "^6.2.2",
     "insight": "^0.10.1",

--- a/test/cli-autocannon.test.js
+++ b/test/cli-autocannon.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+const raw = String.raw
+
+test('clinic --autocannon with $PORT', function (t) {
+  cli({ relayStderr: false }, [
+    'clinic', 'doctor', '--no-open',
+    '--autocannon', '[', 'localhost:$PORT', '-d', '1', ']',
+    '--', 'node', '-e', `
+      const http = require('http')
+
+      http.createServer((req, res) => res.end('ok')).listen(0)
+    `
+  ], function (err, stdout, stderr) {
+    t.ifError(err)
+    t.ok(stderr.indexOf('Running 1s test @ http://localhost:') > -1)
+    t.strictEqual(stdout.split('\n')[0], 'Analysing data')
+    t.end()
+  })
+})
+
+test('clinic --autocannon with escaped $', function (t) {
+  cli({ relayStderr: false }, [
+    'clinic', 'doctor', '--no-open',
+    '--autocannon', '[', raw`localhost:$PORT/\$PORT?\$page=10`, '-d', '1', ']',
+    '--', 'node', '-e', `
+      const http = require('http')
+
+      let first = true
+      http.createServer((req, res) => {
+        if (first) console.log(req.url)
+        first = false
+        res.end('ok')
+      }).listen(0)
+    `
+  ], function (err, stdout, stderr) {
+    console.log(stdout)
+    t.ifError(err)
+    t.ok(stderr.indexOf('Running 1s test @ http://localhost:') > -1)
+    t.strictEqual(stdout.split('\n')[0], '/$PORT?$page=10')
+    t.strictEqual(stdout.split('\n')[1], 'Analysing data')
+    t.end()
+  })
+})
+
+test('clinic --autocannon with /path', function (t) {
+  cli({ relayStderr: false }, [
+    'clinic', 'doctor', '--no-open',
+    '--autocannon', '[', '/path', '-d', '1', ']',
+    '--', 'node', '-e', `
+      const http = require('http')
+
+      http.createServer((req, res) => res.end(req.url)).listen(0)
+    `
+  ], function (err, stdout, stderr) {
+    console.log(stdout)
+    t.ifError(err)
+    t.ok(stderr.indexOf('Running 1s test @ http://localhost:') > -1)
+    t.strictEqual(stdout.split('\n')[0], 'Analysing data')
+    t.end()
+  })
+})

--- a/test/cli-autocannon.test.js
+++ b/test/cli-autocannon.test.js
@@ -36,7 +36,6 @@ test('clinic --autocannon with escaped $', function (t) {
       }).listen(0)
     `
   ], function (err, stdout, stderr) {
-    console.log(stdout)
     t.ifError(err)
     t.ok(stderr.indexOf('Running 1s test @ http://localhost:') > -1)
     t.strictEqual(stdout.split('\n')[0], '/$PORT?$page=10')
@@ -55,7 +54,6 @@ test('clinic --autocannon with /path', function (t) {
       http.createServer((req, res) => res.end(req.url)).listen(0)
     `
   ], function (err, stdout, stderr) {
-    console.log(stdout)
     t.ifError(err)
     t.ok(stderr.indexOf('Running 1s test @ http://localhost:') > -1)
     t.strictEqual(stdout.split('\n')[0], 'Analysing data')


### PR DESCRIPTION
env-string@1.0.1 supports backslash-escapes, this adds some tests.