### PR TITLE
Set default output directory to $cwd/.clinic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # clinic specific
-*.clinic-doctor
-*.clinic-doctor.html
+.clinic
 *.tmp
 !test/fixtures/**/*.clinic-*
 

--- a/bin.js
+++ b/bin.js
@@ -326,7 +326,7 @@ const result = commist()
       default: {
         open: true,
         debug: false,
-        'dest': DEFAULT_DEST
+        dest: DEFAULT_DEST
       },
       '--': true
     })
@@ -365,7 +365,7 @@ const result = commist()
       default: {
         open: true,
         debug: false,
-        'dest': DEFAULT_DEST
+        dest: DEFAULT_DEST
       },
       '--': true
     })

--- a/bin.js
+++ b/bin.js
@@ -29,6 +29,7 @@ const tarAndUploadPromisified = promisify(tarAndUpload)
 
 const GA_TRACKING_CODE = 'UA-29381785-8'
 const DEFAULT_UPLOAD_URL = 'https://upload.clinicjs.org'
+const DEFAULT_DEST = '.clinic'
 
 const insight = new Insight({
   trackingCode: GA_TRACKING_CODE,
@@ -285,7 +286,8 @@ const result = commist()
       default: {
         'sample-interval': '10',
         'open': true,
-        'debug': false
+        'debug': false,
+        'dest': DEFAULT_DEST
       },
       '--': true
     })
@@ -323,7 +325,8 @@ const result = commist()
       ],
       default: {
         open: true,
-        debug: false
+        debug: false,
+        'dest': DEFAULT_DEST
       },
       '--': true
     })
@@ -361,7 +364,8 @@ const result = commist()
       ],
       default: {
         open: true,
-        debug: false
+        debug: false,
+        'dest': DEFAULT_DEST
       },
       '--': true
     })

--- a/docs/clinic-bubbleprof.txt
+++ b/docs/clinic-bubbleprof.txt
@@ -35,4 +35,4 @@
   --visualize-only datapath  Build or rebuild visualization from data
   --on-port                  Run a script when the server starts listening on a port.
   --autocannon               Run the autocannon benchmarking tool when the server starts listening on a port.
-  --dest                     Destination for the collect data (default .).
+  --dest                     Destination for the collected data (default <code>.clinic/</code>).

--- a/docs/clinic-doctor.txt
+++ b/docs/clinic-doctor.txt
@@ -38,4 +38,4 @@
   --sample-interval interval Sample interval in milliseconds
   --on-port                  Run a script when the server starts listening on a port.
   --autocannon               Run the autocannon benchmarking tool when the server starts listening on a port.
-  --dest                     Destination for the collect data (default .).
+  --dest                     Destination for the collected data (default <code>.clinic/</code>).

--- a/docs/clinic-flame.txt
+++ b/docs/clinic-flame.txt
@@ -39,4 +39,4 @@
   --visualize-only datapath  Build or rebuild visualization from data
   --on-port                  Run a script when the server starts listening on a port.
   --autocannon               Run the autocannon benchmarking tool when the server starts listening on a port.
-  --dest                     Destination for the collect data (default .).
+  --dest                     Destination for the collected data (default <code>.clinic/</code>).

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -10,7 +10,7 @@ function clean (dir, cb) {
     if (err) return cb(err)
 
     const pathsToRemove = entries
-      .filter(entry => /^(\d+\.clinic-\w+(\.html)?)|(node_trace\.\d+\.log)$/.test(entry))
+      .filter(entry => /^(\.clinic|\d+\.clinic-\w+(\.html)?|node_trace\.\d+\.log)$/.test(entry))
       .map(entry => path.join(dir, entry))
 
     async.eachSeries(

--- a/test/cli-bubbleprof-collect-only.test.js
+++ b/test/cli-bubbleprof-collect-only.test.js
@@ -11,9 +11,9 @@ test('clinic bubbleprof --collect-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-bubbleprof/.test(stdout))
+    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
 
-    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 
@@ -31,9 +31,9 @@ test('clinic bubbleprof --collect-only - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-bubbleprof/.test(stdout))
+    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
 
-    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 

--- a/test/cli-bubbleprof-collect-only.test.js
+++ b/test/cli-bubbleprof-collect-only.test.js
@@ -11,9 +11,9 @@ test('clinic bubbleprof --collect-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-bubbleprof/.test(stdout))
 
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-bubbleprof)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 
@@ -31,9 +31,9 @@ test('clinic bubbleprof --collect-only - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-bubbleprof/.test(stdout))
 
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-bubbleprof)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 

--- a/test/cli-bubbleprof-full.test.js
+++ b/test/cli-bubbleprof-full.test.js
@@ -13,7 +13,7 @@ test('clinic bubbleprof -- node - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -40,7 +40,7 @@ test('clinic bubbleprof -- node - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -70,6 +70,7 @@ test('clinic bubbleprof -- node - visualization error', function (t) {
 
       // Delete the systeminfo file, such that the visualizer fails.
       fs.unlinkSync(path.join(
+        '.clinic',
         process.pid + '.clinic-bubbleprof',
         process.pid + '.clinic-bubbleprof-systeminfo'
       ))

--- a/test/cli-bubbleprof-full.test.js
+++ b/test/cli-bubbleprof-full.test.js
@@ -13,7 +13,7 @@ test('clinic bubbleprof -- node - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-bubbleprof)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -40,7 +40,7 @@ test('clinic bubbleprof -- node - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-bubbleprof)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)

--- a/test/cli-bubbleprof-visualize-only.test.js
+++ b/test/cli-bubbleprof-visualize-only.test.js
@@ -12,8 +12,8 @@ test('clinic bubbleprof --collect-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-bubbleprof/.test(stdout))
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-bubbleprof)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
@@ -56,8 +56,8 @@ test('clinic bubbleprof --visualize-only - with trailing /', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-bubbleprof/.test(stdout))
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-bubbleprof)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data

--- a/test/cli-bubbleprof-visualize-only.test.js
+++ b/test/cli-bubbleprof-visualize-only.test.js
@@ -12,8 +12,8 @@ test('clinic bubbleprof --collect-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-bubbleprof/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
@@ -56,8 +56,8 @@ test('clinic bubbleprof --visualize-only - with trailing /', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-bubbleprof/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-bubbleprof)/)[1]
+    t.ok(/Output file is \.clinic\/(\d+).clinic-bubbleprof/.test(stdout))
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-bubbleprof)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data

--- a/test/cli-clean-full.test.js
+++ b/test/cli-clean-full.test.js
@@ -15,7 +15,7 @@ test('clinic clean', function (t) {
 
     fs.readdir(tempdir, function (err, files) {
       t.ifError(err)
-      t.equal(files.length, 2) // the folder and html file
+      t.same(files, ['.clinic'])
       fs.writeFileSync(path.join(tempdir, 'some-other-file'), 'sup')
 
       cli({ cwd: tempdir }, ['clinic', 'clean'], function (err) {

--- a/test/cli-doctor-collect-only.test.js
+++ b/test/cli-doctor-collect-only.test.js
@@ -11,9 +11,9 @@ test('clinic doctor --collect-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-doctor/.test(stdout))
 
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-doctor)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 
@@ -31,9 +31,9 @@ test('clinic doctor --collect-only - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-doctor/.test(stdout))
 
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-doctor)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 

--- a/test/cli-doctor-collect-only.test.js
+++ b/test/cli-doctor-collect-only.test.js
@@ -11,9 +11,9 @@ test('clinic doctor --collect-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-doctor/.test(stdout))
+    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
 
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 
@@ -31,9 +31,9 @@ test('clinic doctor --collect-only - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-doctor/.test(stdout))
+    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
 
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
     fs.access(path.resolve(tempdir, dirname), function (err) {
       t.ifError(err)
 

--- a/test/cli-doctor-full.test.js
+++ b/test/cli-doctor-full.test.js
@@ -13,7 +13,7 @@ test('clinic doctor -- node - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -40,7 +40,7 @@ test('clinic doctor -- node - bad status code', function (t) {
     '--', 'node', '-e', 'setTimeout(() => { process.exit(1) }, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -83,6 +83,7 @@ test('clinic doctor -- node - visualization error', function (t) {
 
       // Delete the systeminfo file, such that the visualizer fails.
       fs.unlinkSync(path.join(
+        '.clinic',
         process.pid + '.clinic-doctor',
         process.pid + '.clinic-doctor-systeminfo'
       ))

--- a/test/cli-doctor-full.test.js
+++ b/test/cli-doctor-full.test.js
@@ -13,7 +13,7 @@ test('clinic doctor -- node - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-doctor)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -40,7 +40,7 @@ test('clinic doctor -- node - bad status code', function (t) {
     '--', 'node', '-e', 'setTimeout(() => { process.exit(1) }, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-doctor)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)

--- a/test/cli-doctor-visualize-only.test.js
+++ b/test/cli-doctor-visualize-only.test.js
@@ -12,8 +12,8 @@ test('clinic doctor --visualize-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-doctor/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
@@ -56,8 +56,8 @@ test('clinic doctor --visualize-only - supports trailing slash', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-doctor/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
+    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data

--- a/test/cli-doctor-visualize-only.test.js
+++ b/test/cli-doctor-visualize-only.test.js
@@ -12,8 +12,8 @@ test('clinic doctor --visualize-only - no issues', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-doctor/.test(stdout))
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-doctor)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
@@ -56,8 +56,8 @@ test('clinic doctor --visualize-only - supports trailing slash', function (t) {
     '--', 'node', '-e', 'setTimeout(() => {}, 100)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-doctor/.test(stdout))
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-doctor)/)[1]
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-doctor/.test(stdout))
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-doctor)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data

--- a/test/cli-flame-full.test.js
+++ b/test/cli-flame-full.test.js
@@ -13,7 +13,7 @@ test('clinic flame -- node - no issues', function (t) {
     '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\d+.clinic-flame)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -40,7 +40,7 @@ test('clinic flame -- node - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\d+.clinic-flame)/)[1]
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)

--- a/test/cli-flame-full.test.js
+++ b/test/cli-flame-full.test.js
@@ -13,7 +13,7 @@ test('clinic flame -- node - no issues', function (t) {
     '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-flame)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)
@@ -40,7 +40,7 @@ test('clinic flame -- node - bad status code', function (t) {
     '--', 'node', '-e', 'process.exit(1)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-flame)/)[1]
 
     t.strictEqual(stdout.split('\n')[1], 'Analysing data')
     t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${dirname}.html`)

--- a/test/cli-flame-visualize-only.test.js
+++ b/test/cli-flame-visualize-only.test.js
@@ -12,8 +12,8 @@ test('clinic flame --visualize-only - no issues', function (t) {
     '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-flame/.test(stdout))
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-flame/.test(stdout))
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-flame)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
@@ -56,8 +56,8 @@ test('clinic flame --visualize-only - supports trailing slash', function (t) {
     '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is \.clinic\/(\d+).clinic-flame/.test(stdout))
-    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
+    t.ok(/Output file is \.clinic[/\\](\d+).clinic-flame/.test(stdout))
+    const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-flame)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data

--- a/test/cli-flame-visualize-only.test.js
+++ b/test/cli-flame-visualize-only.test.js
@@ -12,8 +12,8 @@ test('clinic flame --visualize-only - no issues', function (t) {
     '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-flame/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-flame)/)[1]
+    t.ok(/Output file is \.clinic\/(\d+).clinic-flame/.test(stdout))
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data
@@ -56,8 +56,8 @@ test('clinic flame --visualize-only - supports trailing slash', function (t) {
     '--', 'node', '-e', 'require("util").inspect(process)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
-    t.ok(/Output file is (\d+).clinic-flame/.test(stdout))
-    const dirname = stdout.match(/(\d+.clinic-flame)/)[1]
+    t.ok(/Output file is \.clinic\/(\d+).clinic-flame/.test(stdout))
+    const dirname = stdout.match(/(\.clinic\/\d+.clinic-flame)/)[1]
     const dirpath = path.resolve(tempdir, dirname)
 
     // visualize data


### PR DESCRIPTION
Avoids polluting the user's working directory with a ton of different files.

`clinic clean` now removes `.clinic` as well as old-style `{pid}.clinic-{tool}` files.