### PR TITLE
test: allow more time for doctor to take samples

### DIFF
--- a/test/cli-doctor-full.test.js
+++ b/test/cli-doctor-full.test.js
@@ -10,7 +10,7 @@ test('clinic doctor -- node - no issues', function (t) {
   // collect data
   cli({}, [
     'clinic', 'doctor', '--no-open',
-    '--', 'node', '-e', 'setTimeout(() => {}, 100)'
+    '--', 'node', '-e', 'setTimeout(() => {}, 400)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
     const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
@@ -37,7 +37,7 @@ test('clinic doctor -- node - bad status code', function (t) {
   // collect data
   cli({ relayStderr: false }, [
     'clinic', 'doctor', '--no-open',
-    '--', 'node', '-e', 'setTimeout(() => { process.exit(1) }, 100)'
+    '--', 'node', '-e', 'setTimeout(() => { process.exit(1) }, 400)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
     const dirname = stdout.match(/(\d+.clinic-doctor)/)[1]
@@ -134,7 +134,7 @@ test('clinic doctor -- node - configure output destination', function (t) {
   cli({ relayStderr: false }, [
     'clinic', 'doctor', '--no-open',
     '--dest', 'test-doctor-destination',
-    '--', 'node', '-e', 'setTimeout(() => {}, 200)'
+    '--', 'node', '-e', 'setTimeout(() => {}, 400)'
   ], function (err, stdout, stderr, tempdir) {
     t.ifError(err)
     const basename = stdout.match(/(\d+.clinic-doctor)/)[1]


### PR DESCRIPTION
this one has been a bit flakey as of late. they fail because we expect 2+ samples to be taken. normally, 1 should be taken every 10ms. the test programs in our doctor unit tests run for 100ms. sometimes, that's not enough to take 2 samples.
here, i've bumped the runs to take 400ms. in tests in the doctor repo, we allow 100ms of flakiness for the sample interval, so i took that and added a few 100ms more to make sure that we actually have >2 samples.

Closes https://github.com/nearform/node-clinic/issues/131
Closes https://github.com/nearform/node-clinic/issues/139
Closes https://github.com/nearform/node-clinic/issues/140

this should also address the cause of some recent CITGM failure, eg https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1768/nodes=win-vs2017/testReport/(root)/citgm/clinic_v3_1_1/