### PR TITLE
Reduce test output noise

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -72,12 +72,6 @@ function cli (settings, args, callback) {
         })
       }
     }, function (err, result) {
-      // TODO(mcollina): useful for debugging, remove?
-      if (err) {
-        console.log(result.stdout)
-        console.log(result.stderr)
-      }
-
       callback(err,
         result ? result.stdout : null,
         result ? result.stderr : null,


### PR DESCRIPTION
We have quite a few tests that assert that something went wrong in the
expected way, and each of these would log debugging output. That's fine
on its own but it did make test output eg on CITGM quite confusing,
because many of the things that look like failures are actually not.

These can be added back easily locally of course for debugging :)