### PR TITLE
Cleanup temporary profiles after test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pump": "^3.0.0",
     "pumpify": "^1.4.0",
     "rand-token": "^0.4.0",
-    "rimraf": "^2.6.2",
+    "rimraf": "^2.6.3",
     "simple-get": "^3.0.3",
     "split2": "^3.0.0",
     "stream-buffers": "^3.0.2",

--- a/test/cli.js
+++ b/test/cli.js
@@ -5,6 +5,7 @@ const os = require('os')
 const async = require('async')
 const path = require('path')
 const { spawn } = require('child_process')
+const rimraf = require('rimraf')
 const collect = require('stream-collector')
 
 const BIN_PATH = path.resolve(__dirname, '..', 'bin.js')
@@ -28,7 +29,7 @@ function cli (settings, args, callback) {
   }
 
   if (settings.cwd) ondir(null, settings.cwd)
-  else fs.mkdtemp(path.resolve(os.tmpdir(), 'foo-'), ondir)
+  else fs.mkdtemp(path.resolve(os.tmpdir(), 'clinic-test-'), ondir)
 
   function ondir (err, tempdir) {
     if (err) return callback(err)
@@ -72,6 +73,10 @@ function cli (settings, args, callback) {
         })
       }
     }, function (err, result) {
+      process.once('exit', () => {
+        rimraf.sync(tempdir)
+      })
+
       callback(err,
         result ? result.stdout : null,
         result ? result.stderr : null,


### PR DESCRIPTION
Helps with disk space on long running machines (eg CITGM ran into space
issues)

And with RAM usage on low end laptops with an in-memory /tmp :)