### PR TITLE
Display error message from server if available

### DIFF
--- a/lib/tar-and-upload.js
+++ b/lib/tar-and-upload.js
@@ -67,18 +67,24 @@ function tarAndUpload (filePrefix, uploadUrl, authToken, opts, cb) {
 
   function onupload (err, res, body) {
     if (err) return cb(err)
+    let reply
+    try {
+      reply = JSON.parse(body)
+    } catch (err) {}
+
     if (!/^2\d\d$/.test(res.statusCode)) {
-      var error = new Error('Bad status code: ' + res.statusCode)
-      try {
-        error.reply = JSON.parse(body)
-      } catch (err) {}
+      const error = new Error(reply && reply.message ? reply.message : `Bad status code: ${res.statusCode}`)
+      if (reply) {
+        error.reply = reply
+      }
+
       return cb(error)
     }
-    try {
-      var reply = JSON.parse(body)
-    } catch (err) {
-      return cb(err)
+
+    if (reply) {
+      cb(null, reply)
+    } else {
+      cb(new SyntaxError('Could not parse response as JSON'))
     }
-    cb(null, reply)
   }
 }

--- a/test/tar-and-upload.test.js
+++ b/test/tar-and-upload.test.js
@@ -121,6 +121,34 @@ test('upload - bad status code', function (t) {
   })
 })
 
+test('upload - error message from server', function (t) {
+  const dataDirectory = path.resolve(
+    __dirname,
+    'fixtures',
+    'only-folder',
+    `10000.clinic-doctor`
+  )
+
+  const server = http.createServer(function (req, res) {
+    res.statusCode = 400
+    res.end('{"statusCode": 400, "error": "Bad Request", "message": "This is the message"}')
+  })
+
+  server.listen(0, '127.0.0.1', function () {
+    const uploadUrl = `http://localhost:${server.address().port}`
+    tarAndUpload(dataDirectory, uploadUrl, null, {}, function (err) {
+      t.strictDeepEqual(err, Object.assign(new Error('This is the message'), {
+        reply: {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'This is the message'
+        }
+      }))
+      server.close(() => t.end())
+    })
+  })
+})
+
 test('upload fixtures/empty-directory.tmp/10000.clinic-doctor', function (t) {
   const emptyDataDirectory = path.resolve(
     __dirname,


### PR DESCRIPTION
The upload server will have some useful error messages for duplicate uploads or uploads that don't contain any files. This bubbles that information up to the user.