### PR TITLE
Print authentication URL if browser is not available

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -126,7 +126,14 @@ function authenticateViaBrowser (url, isAskFlow = false, isPrivate = false, clea
         isPrivate,
         clearSession
       })
-      open(cliLoginUrl, { wait: false })
+      open(cliLoginUrl, { wait: false }).then((child) => {
+        child.on('exit', (code) => {
+          if (code !== 0) {
+            console.log('Visit this URL to authenticate:')
+            console.log(`  ${cliLoginUrl}`)
+          }
+        })
+      })
     })
   })
 }

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -119,17 +119,24 @@ function authenticateViaBrowser (url, isAskFlow = false, isPrivate = false, clea
       })
 
     ws.once('connect', () => {
-      console.log('Authentication required. Opening the login page in a browser...')
-      // Open the url in the default browser
       const cliLoginUrl = generateBrowserLoginUrl(url, cliToken, {
         isAskFlow,
         isPrivate,
         clearSession
       })
+
+      if (process.env.SSH_CLIENT || process.env.SSH_TTY) {
+        console.log('Authentication required. Please visit this URL to sign in:')
+        console.log(`  ${cliLoginUrl}`)
+        return
+      }
+
+      console.log('Authentication required. Opening the login page in a browser...')
+      // Open the url in the default browser
       open(cliLoginUrl, { wait: false }).then((child) => {
         child.on('exit', (code) => {
           if (code !== 0) {
-            console.log('Visit this URL to authenticate:')
+            console.log('Could not find a browser. Visit this URL to authenticate:')
             console.log(`  ${cliLoginUrl}`)
           }
         })

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -8,6 +8,12 @@ let server, cliToken
 let simulateTimeout = false
 let simulateNoToken = false
 
+function openSuccess () {
+  return Promise.resolve({
+    on: (event, fn) => fn(0)
+  })
+}
+
 test('Before all', function (t) {
   server = http.createServer(() => {})
 
@@ -35,6 +41,7 @@ test('authenticate', async function (t) {
   let openedUrl = ''
   const openStub = url => {
     openedUrl = url
+    return openSuccess()
   }
 
   const authenticate = proxyquire('../lib/authenticate', { open: openStub }) // mocking the browser opening
@@ -49,6 +56,7 @@ test('authenticate for private upload', async function (t) {
   let openedUrl = ''
   const openStub = url => {
     openedUrl = url
+    return openSuccess()
   }
 
   const authenticate = proxyquire('../lib/authenticate', { open: openStub }) // mocking the browser opening
@@ -67,6 +75,7 @@ test('authenticate using ask', async function (t) {
   let openedUrl = ''
   const openStub = url => {
     openedUrl = url
+    return openSuccess()
   }
 
   const authenticate = proxyquire('../lib/authenticate', { open: openStub }) // mocking the browser opening
@@ -82,7 +91,7 @@ test('authenticate using ask', async function (t) {
 })
 
 test('authenticate timeout', async function (t) {
-  const openStub = url => url
+  const openStub = url => openSuccess()
 
   const authenticate = proxyquire('../lib/authenticate', { open: openStub }) // mocking the browser opening
 
@@ -101,7 +110,9 @@ test('authenticate timeout', async function (t) {
 })
 
 test('authenticate no auth token', async function (t) {
-  const authenticate = proxyquire('../lib/authenticate', { open: url => url }) // mocking the browser opening
+  const openStub = url => openSuccess()
+
+  const authenticate = proxyquire('../lib/authenticate', { open: openStub }) // mocking the browser opening
 
   simulateNoToken = true
   try {
@@ -117,10 +128,12 @@ test('authenticate no auth token', async function (t) {
 })
 
 test('authenticate failure', async function (t) {
+  const openStub = url => openSuccess()
+
   const authenticate = proxyquire(
     '../lib/authenticate',
     {
-      open: url => url,
+      open: openStub,
       split2: () => ({ on: () => [] })
     })
 


### PR DESCRIPTION
When in an SSH session, or when a browser cannot be opened using the `open` module, print the authentication link so you can visit it manually.

Initially I only had the `open()` fallback, but I found that some of the servers I tested with had text-based browsers like elinks or w3m installed. When those were launched, `xdg-open` would exit with 0, but the browser would run in the background, impossible to interact with. Hence the explicit SSH check. This probably accounts for the vast majority of likely configurations.

Closes #147