### PR TITLE
Check if npm start passed

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -262,10 +262,8 @@ const result = commist()
   })
   .register('doctor', catchify(async function (argv) {
     const version = require('@nearform/doctor/package.json').version
-    if(argv[0]==='--' && argv[1]==='npm' && argv[2]==='start') {
-      printHelp('clinic-doctor', version)
-      process.exit(1)
-    }
+    checkArgs(argv, 'clinic-doctor', version);
+    
     const args = subarg(argv, {
       alias: {
         help: 'h',
@@ -310,6 +308,8 @@ const result = commist()
   }))
   .register('bubbleprof', catchify(async function (argv) {
     const version = require('@nearform/bubbleprof/package.json').version
+    checkArgs(argv, 'clinic-bubbleprof', version);
+    
     const args = subarg(argv, {
       alias: {
         help: 'h',
@@ -351,6 +351,8 @@ const result = commist()
   }))
   .register('flame', catchify(async function (argv) {
     const version = require('@nearform/flame/version')
+    checkArgs(argv, 'clinic-bubbleprof', version);
+
     const args = subarg(argv, {
       alias: {
         help: 'h',
@@ -422,6 +424,13 @@ function catchify (asyncFn) {
       console.error(err.stack)
       process.exit(1)
     })
+  }
+}
+
+function checkArgs (args,help,version) {
+  if(args[0]==='--' && args[1]!=='node') {
+    printHelp(help, version)
+    process.exit(1)
   }
 }
 

--- a/bin.js
+++ b/bin.js
@@ -262,6 +262,10 @@ const result = commist()
   })
   .register('doctor', catchify(async function (argv) {
     const version = require('@nearform/doctor/package.json').version
+    if(argv[0]==='--' && argv[1]==='npm' && argv[2]==='start') {
+      printHelp('clinic-doctor', version)
+      process.exit(1)
+    }
     const args = subarg(argv, {
       alias: {
         help: 'h',

--- a/bin.js
+++ b/bin.js
@@ -262,8 +262,8 @@ const result = commist()
   })
   .register('doctor', catchify(async function (argv) {
     const version = require('@nearform/doctor/package.json').version
-    checkArgs(argv, 'clinic-doctor', version);
-    
+    checkArgs(argv, 'clinic-doctor', version)
+
     const args = subarg(argv, {
       alias: {
         help: 'h',
@@ -308,8 +308,8 @@ const result = commist()
   }))
   .register('bubbleprof', catchify(async function (argv) {
     const version = require('@nearform/bubbleprof/package.json').version
-    checkArgs(argv, 'clinic-bubbleprof', version);
-    
+    checkArgs(argv, 'clinic-bubbleprof', version)
+
     const args = subarg(argv, {
       alias: {
         help: 'h',
@@ -351,7 +351,7 @@ const result = commist()
   }))
   .register('flame', catchify(async function (argv) {
     const version = require('@nearform/flame/version')
-    checkArgs(argv, 'clinic-bubbleprof', version);
+    checkArgs(argv, 'clinic-bubbleprof', version)
 
     const args = subarg(argv, {
       alias: {
@@ -427,8 +427,8 @@ function catchify (asyncFn) {
   }
 }
 
-function checkArgs(args, help, version) {
-  if(args[0]==='--' && args[1]!=='node') {
+function checkArgs (args, help, version) {
+  if (args[0] === '--' && args[1] !== 'node') {
     printHelp(help, version)
     process.exit(1)
   }

--- a/bin.js
+++ b/bin.js
@@ -427,7 +427,7 @@ function catchify (asyncFn) {
   }
 }
 
-function checkArgs (args,help,version) {
+function checkArgs(args, help, version) {
   if(args[0]==='--' && args[1]!=='node') {
     printHelp(help, version)
     process.exit(1)


### PR DESCRIPTION
Looking to solve issue #194. At the moment this will:

- Check the params passed for npm start.
- Exit the process. 
- Show help for doctor.

Could potentially change the params check to be !node instead and throw error instead of showing help for doctor. As it stands this behaviour is better since it doesn't follow the process right to the very end like it did before.
