### PR TITLE
Start profiling after a timeout

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -437,12 +437,16 @@ function checkArgs (args, help, version) {
     printHelp(help, version)
     process.exit(1)
   }
-  // Check for timeout and set the timeout delay
-  const timeout = args.filter(a => a.includes('timeout'))
-  const delay = timeout.toString().split('=')[1]
+  // Check for timeout usage and set the timeout delay
+  const delayused = args.toString().includes('timeout')
 
-  const now = process.hrtime()
-  while (deltams(now) < delay) { }
+  if (delayused) {
+    const timeout = args.filter(a => a.includes('timeout'))
+    const delay = timeout.toString().split('=')[1]
+
+    const now = process.hrtime()
+    while (deltams(now) < delay) { }
+  }
 }
 
 function checkMetricsPermission (cb) {

--- a/bin.js
+++ b/bin.js
@@ -427,6 +427,11 @@ function catchify (asyncFn) {
   }
 }
 
+function deltams (now) {
+  const delta = process.hrtime(now)
+  return delta[0] * 1e3 + delta[1] * 1e-6
+}
+
 function checkArgs (args, help, version) {
   if (args[0] === '--' && args[1] !== 'node') {
     printHelp(help, version)
@@ -435,6 +440,9 @@ function checkArgs (args, help, version) {
   // Check for timeout and set the timeout delay
   const timeout = args.filter(a => a.includes('timeout'))
   const delay = timeout.toString().split('=')[1]
+
+  const now = process.hrtime()
+  while (deltams(now) < delay) { }
 }
 
 function checkMetricsPermission (cb) {

--- a/bin.js
+++ b/bin.js
@@ -432,6 +432,9 @@ function checkArgs (args, help, version) {
     printHelp(help, version)
     process.exit(1)
   }
+  // Check for timeout and set the timeout delay
+  const timeout = args.filter(a => a.includes('timeout'))
+  const delay = timeout.toString().split('=')[1]
 }
 
 function checkMetricsPermission (cb) {


### PR DESCRIPTION
Take in a timeout argument and delay data collection by the timeout delay provided.