### PR TITLE
Drop support for Node.js < 10.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ these factors together.
 ## Supported Node.js versions
 
 Clinic.js relies heavily on Node.js core instrumentation available in later versions.
-Currently the supported Node.js versions are `^10.0.0` and `^8.9.4`.
+Currently the supported Node.js versions are `>= 10.12.0`.
 
 ## Examples and Demos
 

--- a/azure-pipelines-npm-template.yml
+++ b/azure-pipelines-npm-template.yml
@@ -11,9 +11,7 @@ jobs:
       node_11_x:
         node_version: 11.x
       node_10_x:
-        node_version: 10.x
-      node_8_x:
-        node_version: 8.x
+        node_version: ^10.12.0
     maxParallel: 5
   steps:
   - task: NodeTool@0
@@ -26,7 +24,3 @@ jobs:
     displayName: Check linting
   - bash: npm run ci-test-cov
     displayName: Run tests with code coverage
-    condition: ne(variables['node_version'], '8.x')
-  - bash: npm run ci-test-no-cov
-    displayName: Run tests without code coverage
-    condition: eq(variables['node_version'], '8.x')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "nearform/node-clinic",
   "version": "5.0.0",
   "engines": {
-    "node": "^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.0.0 || ^8.11.1"
+    "node": "^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.12.0"
   },
   "bin": {
     "clinic": "./bin.js"


### PR DESCRIPTION
Node.js 8 is no longer officially supported, and we're using an API from Node.js 10.12 now.