### PR TITLE
Tweak `node` argument check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .clinic
 *.tmp
 !test/fixtures/**/*.clinic-*
+test/fixtures/**/ASK_MESSAGE
 
 # Logs
 logs

--- a/bin.js
+++ b/bin.js
@@ -263,7 +263,6 @@ const result = commist()
   })
   .register('doctor', catchify(async function (argv) {
     const version = require('@nearform/doctor/package.json').version
-    checkArgs(argv, 'clinic-doctor', version)
 
     const args = subarg(argv, {
       alias: {
@@ -300,6 +299,7 @@ const result = commist()
     } else if (args.help) {
       printHelp('clinic-doctor', version)
     } else if (args['visualize-only'] || args['--'].length > 1) {
+      checkArgs(args, 'clinic-doctor', version)
       await trackTool('doctor', args, version)
       await runTool(args, require('@nearform/doctor'), version, { color: 'green' })
     } else {
@@ -309,7 +309,6 @@ const result = commist()
   }))
   .register('bubbleprof', catchify(async function (argv) {
     const version = require('@nearform/bubbleprof/package.json').version
-    checkArgs(argv, 'clinic-bubbleprof', version)
 
     const args = subarg(argv, {
       alias: {
@@ -343,6 +342,7 @@ const result = commist()
     } else if (args.help) {
       printHelp('clinic-bubbleprof', version)
     } else if (args['visualize-only'] || args['--'].length > 1) {
+      checkArgs(args, 'clinic-bubbleprof', version)
       await trackTool('bubbleprof', args, version)
       await runTool(args, require('@nearform/bubbleprof'), version, { color: 'blue' })
     } else {
@@ -352,7 +352,6 @@ const result = commist()
   }))
   .register('flame', catchify(async function (argv) {
     const version = require('@nearform/flame/version')
-    checkArgs(argv, 'clinic-flame', version)
 
     const args = subarg(argv, {
       alias: {
@@ -386,6 +385,7 @@ const result = commist()
     } else if (args.help) {
       printHelp('clinic-flame', version)
     } else if (args['visualize-only'] || args['--'].length > 1) {
+      checkArgs(args, 'clinic-flame', version)
       await trackTool('flame', args, version)
       await runTool(args, require('@nearform/flame'), version, { color: 'yellow' })
     } else {
@@ -429,7 +429,9 @@ function catchify (asyncFn) {
 }
 
 function checkArgs (args, help, version) {
-  if (args[0] === '--' && args[1] !== 'node') {
+  if (args['--'] && args['--'].length >= 1 && path.basename(args['--'][0]) !== 'node') {
+    console.error('Clinic.js must be called with a `node` command line: `clinic doctor -- node script.js`\n')
+
     printHelp(help, version)
     process.exit(1)
   }

--- a/test/cli-bubbleprof-non-node.test.js
+++ b/test/cli-bubbleprof-non-node.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic bubbleprof - should error early if non-node script', function (t) {
+  cli({}, ['clinic', 'bubbleprof', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js BubbleProf[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic bubbleprof --collect-only - should error early if non-node script', function (t) {
+  cli({}, ['clinic', 'bubbleprof', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js BubbleProf[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic bubbleprof - should accept full path to node.js', function (t) {
+  cli({}, ['clinic', 'bubbleprof', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
+    t.ifError(err)
+    t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-bubbleprof/.test(stdout))
+    t.end()
+  })
+})

--- a/test/cli-doctor-non-node.test.js
+++ b/test/cli-doctor-non-node.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic doctor - should error early if non-node script', function (t) {
+  cli({}, ['clinic', 'doctor', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js Doctor[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic doctor --collect-only - should error early if non-node script', function (t) {
+  cli({}, ['clinic', 'doctor', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js Doctor[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic doctor - should accept full path to node.js', function (t) {
+  cli({}, ['clinic', 'doctor', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
+    t.ifError(err)
+    t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-doctor/.test(stdout))
+    t.end()
+  })
+})

--- a/test/cli-flame-non-node.test.js
+++ b/test/cli-flame-non-node.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic flame - should error early if non-node script', function (t) {
+  cli({}, ['clinic', 'flame', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js Flame[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic flame --collect-only - should error early if non-node script', function (t) {
+  cli({}, ['clinic', 'flame', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js Flame[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic flame - should accept full path to node.js', function (t) {
+  cli({}, ['clinic', 'flame', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
+    t.ifError(err)
+    t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-flame/.test(stdout))
+    t.end()
+  })
+})


### PR DESCRIPTION
Noticed something was missing from the `clinic tool -- node x.js` check
that we added recently. Its purpose is to prevent you from doing things
like `clinic tool -- sh wrapper.sh`, which is unsupported. But the check
was a bit too tight: it prevented that exact input, but not inputs with
additional flags like `clinic tool --no-open -- sh wrapper.sh`. This
change fixes that, adds support for providing full paths to the node.js
binary like `clinic tool -- /usr/bin/node script.js`, and adds tests.