### PR TITLE
ci: add node 14

### DIFF
--- a/azure-pipelines-npm-template.yml
+++ b/azure-pipelines-npm-template.yml
@@ -4,6 +4,8 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
+      node_14_x:
+        node_version: 14.x
       node_13_x:
         node_version: 13.x
       node_12_x:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "nearform/node-clinic",
   "version": "5.0.1",
   "engines": {
-    "node": "^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.12.0"
+    "node": "^14.0.0 || ^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.12.0"
   },
   "bin": {
     "clinic": "./bin.js"


### PR DESCRIPTION
Similar to https://github.com/nearform/node-clinic/pull/193
Node.js 14.x was released on 2020-04-21 https://github.com/nodejs/Release