### PR TITLE
accept `node.exe` in argument check

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -429,7 +429,7 @@ function catchify (asyncFn) {
 }
 
 function checkArgs (args, help, version) {
-  if (args['--'] && args['--'].length >= 1 && !/^node(\.exe)$/.test(path.basename(args['--'][0]))) {
+  if (args['--'] && args['--'].length >= 1 && !/^node(\.exe)?$/.test(path.basename(args['--'][0]))) {
     console.error('Clinic.js must be called with a `node` command line: `clinic doctor -- node script.js`\n')
 
     printHelp(help, version)

--- a/bin.js
+++ b/bin.js
@@ -429,7 +429,7 @@ function catchify (asyncFn) {
 }
 
 function checkArgs (args, help, version) {
-  if (args['--'] && args['--'].length >= 1 && path.basename(args['--'][0]) !== 'node') {
+  if (args['--'] && args['--'].length >= 1 && !/^node(\.exe)$/.test(path.basename(args['--'][0]))) {
     console.error('Clinic.js must be called with a `node` command line: `clinic doctor -- node script.js`\n')
 
     printHelp(help, version)


### PR DESCRIPTION
Oops, this was causing all tests to fail on Windows :)

Followup to #230