### PR TITLE
Add node 14 to supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "nearform/node-clinic",
   "version": "6.0.2",
   "engines": {
-    "node": "^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.12.0"
+    "node": "^14.0.0 || ^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.12.0"
   },
   "bin": {
     "clinic": "./bin.js"


### PR DESCRIPTION
As far as I can see this is the only thing in order to fix https://github.com/nearform/node-clinic/issues/254.

Node 14 is already in the ci workflow and all tests are green. I also tested it locally on some simple apps and it appears to be working properly.

Linked to this I also added node 14 to the ci workflow of doctor, bubbleprof and flame to make sure they independently work with Node 14:
https://github.com/nearform/node-clinic-doctor/pull/334
https://github.com/nearform/node-clinic-flame/pull/130
https://github.com/nearform/node-clinic-flame/pull/130
