### PR TITLE
v11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clinic",
   "description": "Clinic.js diagnoses your performance issues",
   "repository": "clinicjs/node-clinic",
-  "version": "11.1.1",
+  "version": "11.1.2",
   "engines": {
     "node": ">= 12.22.7"
   },


### PR DESCRIPTION
I thought I had permissions to bump a new version directly to the `main`. But, it just created a new tag(11.1.1) and I wouldn't able to push the commit neither delete the tag.

So, here we go `v11.1.2` (the package was already published to NPM)
